### PR TITLE
Add loudness analysis, normalization, and cue preservation

### DIFF
--- a/apps/desktop/src/main/ffmpeg.test.ts
+++ b/apps/desktop/src/main/ffmpeg.test.ts
@@ -9,7 +9,9 @@ import {
   coverArgs,
   cutoffFilter,
   formatMatchesInput,
+  parseAstats,
   parseBands,
+  parseLoudness,
   planConversion,
   previewWavArgs,
   tagsFromProbe,
@@ -46,6 +48,27 @@ describe('convertArgs', () => {
     const args = convertArgs('/in.aiff', '/out.tmp.aiff', 'copy', meta)
     const i = args.indexOf('-c:a')
     expect(args[i + 1]).toBe('copy')
+  })
+
+  it('inserts the normalization audio filter before the codec, ahead of -c:a', () => {
+    const args = convertArgs(
+      '/in.wav',
+      '/o.aiff',
+      'pcm_s16be',
+      meta,
+      undefined,
+      undefined,
+      'volume=3dB',
+    )
+    const af = args.indexOf('-af')
+    expect(af).toBeGreaterThan(-1)
+    expect(args[af + 1]).toBe('volume=3dB')
+    // the filter must apply before the audio codec is selected
+    expect(af).toBeLessThan(args.indexOf('-c:a'))
+  })
+
+  it('omits -af entirely when no filter is given, leaving a plain conversion', () => {
+    expect(convertArgs('/in.wav', '/o.aiff', 'pcm_s16be', meta)).not.toContain('-af')
   })
 
   it('maps the cover as attached art only when a cover is provided', () => {
@@ -115,6 +138,24 @@ describe('planConversion', () => {
     expect(await planConversion('/in.flac', 'flac', probe)).toEqual({ codec: 'copy', ext: '.flac' })
     // copying never needs to inspect the stream
     expect(probe).not.toHaveBeenCalled()
+  })
+
+  it('never stream-copies when normalizing, since the gain filter must re-encode the samples', async () => {
+    // Same-format sources that would normally copy must encode instead, or the
+    // normalization would be silently dropped (a stream copy emits the source bytes).
+    expect(await planConversion('/in.mp3', 'mp3', probe, true)).toEqual({
+      codec: 'libmp3lame',
+      bitrate: '320k',
+      ext: '.mp3',
+    })
+    expect(await planConversion('/in.aiff', 'aiff', probe, true)).toEqual({
+      codec: 'pcm_s24be',
+      ext: '.aiff',
+    })
+    expect(await planConversion('/in.flac', 'flac', probe, true)).toEqual({
+      codec: 'flac',
+      ext: '.flac',
+    })
   })
 
   it('transcodes an AAC/M4A source to every target instead of stream-copying', async () => {
@@ -272,6 +313,135 @@ describe('parseBands', () => {
       'lavfi.astats.Overall.RMS_level=-31.2',
     ].join('\n')
     expect(parseBands(out).get(9000)).toBe(-31.2)
+  })
+})
+
+describe('parseLoudness', () => {
+  // A real ebur128=peak=true summary, printed to stderr at info level. The "LRA
+  // low/high" lines and the per-section "Threshold" lines must not be mistaken for
+  // the integrated I, the LRA, or the true peak we actually surface.
+  const summary = [
+    '[Parsed_ebur128_0 @ 0x600000] Summary:',
+    '',
+    '  Integrated loudness:',
+    '    I:         -14.7 LUFS',
+    '    Threshold: -25.0 LUFS',
+    '',
+    '  Loudness range:',
+    '    LRA:         7.6 LU',
+    '    Threshold: -35.0 LUFS',
+    '    LRA low:   -19.2 LUFS',
+    '    LRA high:  -11.6 LUFS',
+    '',
+    '  True peak:',
+    '    Peak:       -0.5 dBFS',
+  ].join('\n')
+
+  it('reads integrated loudness, true peak and loudness range, ignoring the threshold and LRA low/high rows', () => {
+    expect(parseLoudness(summary)).toEqual({
+      integratedLufs: -14.7,
+      truePeakDb: -0.5,
+      lra: 7.6,
+    })
+  })
+
+  it('maps a -inf integrated loudness or true peak (digital silence) to -Infinity so the UI can show it rather than NaN', () => {
+    const silent = summary
+      .replace('I:         -14.7 LUFS', 'I:         -inf LUFS')
+      .replace('Peak:       -0.5 dBFS', 'Peak:       -inf dBFS')
+    expect(parseLoudness(silent)).toEqual({
+      integratedLufs: -Infinity,
+      truePeakDb: -Infinity,
+      lra: 7.6,
+    })
+  })
+
+  it('returns null when the summary is absent (e.g. ffmpeg failed before measuring) so the caller hides the readout instead of inventing zeros', () => {
+    expect(parseLoudness('ffmpeg version 7.0\nsome unrelated error\n')).toBeNull()
+  })
+
+  it('reads the final Summary, not the per-frame log: at t≈0 ebur128 prints the -70 LUFS gate floor and 0.0 LU, which would brand a loud track as near-silent', () => {
+    // Real shape: a stream of per-frame lines (each with its own I:/LRA:) followed
+    // by the Summary. The bug was matching the first I: (the gate floor) instead.
+    const withFrames = [
+      '[Parsed_ebur128_0 @ 0x1] t: 0.1  TARGET:-23 LUFS  M:-120.7 S:-120.7  I: -70.0 LUFS  LRA: 0.0 LU  TPK: 2.5 1.4 dBFS',
+      '[Parsed_ebur128_0 @ 0x1] t: 0.4  TARGET:-23 LUFS  M:  -5.2 S:-120.7  I:  -5.2 LUFS  LRA: 0.0 LU  TPK: 2.5 1.7 dBFS',
+      summary
+        .replace('I:         -14.7 LUFS', 'I:          -6.2 LUFS')
+        .replace('LRA:         7.6 LU', 'LRA:         5.2 LU')
+        .replace('Peak:       -0.5 dBFS', 'Peak:        2.5 dBFS'),
+    ].join('\n')
+    expect(parseLoudness(withFrames)).toEqual({
+      integratedLufs: -6.2,
+      truePeakDb: 2.5,
+      lra: 5.2,
+    })
+  })
+})
+
+describe('parseAstats', () => {
+  // astats prints a per-channel block then an Overall block; each line carries a
+  // "[Parsed_astats_0 @ ...] " prefix the parser must strip. Channel RMS gives the
+  // L/R balance; the Overall DC offset flags a biased capture.
+  const stats = [
+    '[Parsed_astats_0 @ 0x1] Channel: 1',
+    '[Parsed_astats_0 @ 0x1] DC offset: 0.000035',
+    '[Parsed_astats_0 @ 0x1] RMS level dB: -15.933728',
+    '[Parsed_astats_0 @ 0x1] Channel: 2',
+    '[Parsed_astats_0 @ 0x1] DC offset: 0.000026',
+    '[Parsed_astats_0 @ 0x1] RMS level dB: -16.689935',
+    '[Parsed_astats_0 @ 0x1] Overall',
+    '[Parsed_astats_0 @ 0x1] DC offset: 0.000040',
+    '[Parsed_astats_0 @ 0x1] Peak level dB: -0.154044',
+    '[Parsed_astats_0 @ 0x1] RMS level dB: -16.295393',
+    '[Parsed_astats_0 @ 0x1] Noise floor dB: -45.202488',
+  ].join('\n')
+
+  it('derives balance from per-channel RMS, and DC/crest/noise floor from the Overall block', () => {
+    const r = parseAstats(stats)
+    expect(r?.balanceDb).toBeCloseTo(0.756, 2)
+    expect(r?.dcOffset).toBeCloseTo(0.00004, 5)
+    // crest = Overall peak − Overall RMS = -0.154 − (-16.295)
+    expect(r?.crestDb).toBeCloseTo(16.141, 2)
+    expect(r?.noiseFloorDb).toBeCloseTo(-45.2, 1)
+  })
+
+  it('reports a null balance for mono, where there is no second channel to compare', () => {
+    const mono = [
+      '[Parsed_astats_0 @ 0x1] Channel: 1',
+      '[Parsed_astats_0 @ 0x1] DC offset: 0.001',
+      '[Parsed_astats_0 @ 0x1] RMS level dB: -14.0',
+      '[Parsed_astats_0 @ 0x1] Overall',
+      '[Parsed_astats_0 @ 0x1] DC offset: 0.001',
+      '[Parsed_astats_0 @ 0x1] RMS level dB: -14.0',
+    ].join('\n')
+    expect(parseAstats(mono)?.balanceDb).toBeNull()
+  })
+
+  it('takes the absolute DC offset, since a negative bias is just as wrong as a positive one', () => {
+    const negative = stats.replace('DC offset: 0.000040', 'DC offset: -0.030000')
+    expect(parseAstats(negative)?.dcOffset).toBeCloseTo(0.03, 4)
+  })
+
+  // The reported AIFF bug: a dead channel reads "-inf" and DC prints "nan", which
+  // used to surface as "−∞ dB" and "NaN%". Both must be dropped to null and hidden.
+  it('drops non-finite readings (a silent channel reading -inf, a nan DC offset) instead of showing −∞/NaN', () => {
+    const broken = [
+      '[Parsed_astats_0 @ 0x1] Channel: 1',
+      '[Parsed_astats_0 @ 0x1] RMS level dB: -14.0',
+      '[Parsed_astats_0 @ 0x1] Channel: 2',
+      '[Parsed_astats_0 @ 0x1] RMS level dB: -inf',
+      '[Parsed_astats_0 @ 0x1] Overall',
+      '[Parsed_astats_0 @ 0x1] DC offset: nan',
+      '[Parsed_astats_0 @ 0x1] RMS level dB: -14.0',
+    ].join('\n')
+    const r = parseAstats(broken)
+    expect(r?.balanceDb).toBeNull()
+    expect(r?.dcOffset).toBeNull()
+  })
+
+  it('returns null when no astats block is present so the caller hides the checks', () => {
+    expect(parseAstats('ffmpeg version 7.0\n')).toBeNull()
   })
 })
 

--- a/apps/desktop/src/main/ffmpeg.ts
+++ b/apps/desktop/src/main/ffmpeg.ts
@@ -15,7 +15,7 @@ import {
   volumedetectArgs,
   volumeFilter,
 } from './normalize'
-import { preservesCuesInPlace, writeTags } from './tags'
+import { copyCueFrames, preservesCuesInPlace, writeTags } from './tags'
 import { tmpName } from './tmp'
 
 // Re-exported so the existing main-process imports (index.ts, tests) keep their
@@ -337,6 +337,10 @@ export async function convertAudio(
         // and grouping — and which ffmpeg reads back as a video stream on re-import.
         writeTags(tmp, meta, coverPath)
       }
+      // Normalizing forces this re-encode, which drops Traktor's GEOB cue/beatgrid
+      // frame. A constant gain never moves the cues in time, so carry the frame over
+      // from the source — but only for the ID3 containers it round-trips through.
+      if (normalizing && preservesCuesInPlace(ext)) copyCueFrames(input, tmp)
     }
     await rename(tmp, output)
   } catch (e) {

--- a/apps/desktop/src/main/ffmpeg.ts
+++ b/apps/desktop/src/main/ffmpeg.ts
@@ -3,9 +3,18 @@ import { copyFile, readFile, rename, unlink } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { promisify } from 'node:util'
-import type { OutputFormat, TrackMetadata } from '../shared/types'
+import type { LoudnessResult, NormalizeConfig, OutputFormat, TrackMetadata } from '../shared/types'
 import { ffmpegPath, ffprobePath } from './binaries'
 import { BAND_WIDTH_HZ, bandFrequencies, detectCutoff } from './cutoff'
+import {
+  loudnormArgs,
+  loudnormFilter,
+  parseLoudnorm,
+  parseMaxVolume,
+  peakGainDb,
+  volumedetectArgs,
+  volumeFilter,
+} from './normalize'
 import { preservesCuesInPlace, writeTags } from './tags'
 import { tmpName } from './tmp'
 
@@ -207,6 +216,7 @@ export function convertArgs(
   meta: TrackMetadata,
   coverPath?: string,
   bitrate?: string,
+  audioFilter?: string,
 ): string[] {
   // WAV is a single-stream RIFF container, so ffmpeg refuses to mux an attached
   // picture into it ("WAVE files have exactly one stream"). The cover still
@@ -218,6 +228,8 @@ export function convertArgs(
   args.push('-map', '0:a')
   if (embedCover) args.push('-map', '1:v', '-c:v', 'copy', '-disposition:v:0', 'attached_pic')
 
+  // Normalization filter (loudnorm / volume), applied to the audio before encoding.
+  if (audioFilter) args.push('-af', audioFilter)
   args.push('-c:a', codec)
   if (bitrate) args.push('-b:a', bitrate)
   args.push('-write_id3v2', '1', '-id3v2_version', '3')
@@ -237,27 +249,52 @@ export interface ConversionPlan {
 // otherwise it encodes — lossless to bit-depth-preserving PCM for AIFF/WAV
 // (big-endian for AIFF, little-endian for WAV), or to a fixed 320 kbps for MP3.
 // The bit depth only matters for the lossless targets, so MP3 skips the probe.
+// `normalize` forces a re-encode: applying a loudness/peak filter changes the
+// samples, so a stream copy (which would emit the untouched source) is never
+// valid — every matching-format shortcut is gated on it being off.
 export async function planConversion(
   input: string,
   format: OutputFormat,
   probe: (input: string) => Promise<ProbeResult>,
+  normalize = false,
 ): Promise<ConversionPlan> {
   if (format === 'mp3') {
-    if (MP3_INPUT.test(input)) return { codec: 'copy', ext: '.mp3' }
+    if (MP3_INPUT.test(input) && !normalize) return { codec: 'copy', ext: '.mp3' }
     return { codec: 'libmp3lame', bitrate: MP3_BITRATE, ext: '.mp3' }
   }
   if (format === 'wav') {
-    if (WAV_INPUT.test(input)) return { codec: 'copy', ext: '.wav' }
+    if (WAV_INPUT.test(input) && !normalize) return { codec: 'copy', ext: '.wav' }
     return { codec: pcmCodec(await probe(input), 'le'), ext: '.wav' }
   }
   if (format === 'flac') {
     // FLAC is losslessly compressed and the encoder reads the source bit depth
     // itself, so there is no PCM width or endianness to choose — no probe needed.
-    if (FLAC_INPUT.test(input)) return { codec: 'copy', ext: '.flac' }
+    if (FLAC_INPUT.test(input) && !normalize) return { codec: 'copy', ext: '.flac' }
     return { codec: 'flac', ext: '.flac' }
   }
-  if (AIFF_INPUT.test(input)) return { codec: 'copy', ext: '.aiff' }
+  if (AIFF_INPUT.test(input) && !normalize) return { codec: 'copy', ext: '.aiff' }
   return { codec: pcmCodec(await probe(input), 'be'), ext: '.aiff' }
+}
+
+// Resolves the audio filter for the chosen normalization, running the required
+// measurement pass first: a two-pass linear loudnorm for the loudness target, or
+// volumedetect + a constant gain for peak. Returns null (no filter) for mode
+// 'none' and whenever the measurement can't be parsed, so a measurement failure
+// degrades to a plain conversion instead of aborting it.
+export async function normalizeFilter(input: string, cfg: NormalizeConfig): Promise<string | null> {
+  if (cfg.mode === 'none') return null
+  if (cfg.mode === 'peak') {
+    const { stderr } = await run(ffmpegPath, volumedetectArgs(input), {
+      maxBuffer: 1024 * 1024 * 16,
+    })
+    const max = parseMaxVolume(stderr)
+    return max === null ? null : volumeFilter(peakGainDb(cfg.peakDb, max))
+  }
+  const { stderr } = await run(ffmpegPath, loudnormArgs(input, cfg), {
+    maxBuffer: 1024 * 1024 * 16,
+  })
+  const measured = parseLoudnorm(stderr)
+  return measured ? loudnormFilter(cfg, measured) : null
 }
 
 export async function convertAudio(
@@ -266,12 +303,20 @@ export async function convertAudio(
   format: OutputFormat,
   meta: TrackMetadata,
   coverPath?: string,
+  normalize?: NormalizeConfig,
 ): Promise<void> {
   // We always write to a temp file and rename it over the target, so
   // re-processing a file that already lives in the output folder (input path ===
   // output path) overwrites it atomically instead of failing with ffmpeg's
   // "Output same as Input" error.
-  const { codec, bitrate, ext } = await planConversion(input, format, probeAudio)
+  // Re-encoding through ffmpeg drops Traktor's GEOB cues regardless, so the gain
+  // filter only ever rides the encode path — planConversion is told to skip the
+  // stream-copy shortcuts when normalizing.
+  const normalizing = normalize !== undefined && normalize.mode !== 'none'
+  const audioFilter = normalizing
+    ? ((await normalizeFilter(input, normalize)) ?? undefined)
+    : undefined
+  const { codec, bitrate, ext } = await planConversion(input, format, probeAudio, normalizing)
   const tmp = output.replace(new RegExp(`\\${ext}$`, 'i'), `.tmp${ext}`)
 
   try {
@@ -282,7 +327,7 @@ export async function convertAudio(
       await copyFile(input, tmp)
       writeTags(tmp, meta, coverPath)
     } else {
-      await run(ffmpegPath, convertArgs(input, tmp, codec, meta, coverPath, bitrate), {
+      await run(ffmpegPath, convertArgs(input, tmp, codec, meta, coverPath, bitrate, audioFilter), {
         maxBuffer: 1024 * 1024 * 32,
       })
       if (ext === '.wav') {
@@ -446,6 +491,124 @@ export async function analyzeCutoff(input: string, sampleRateHz: number): Promis
   const rms = parseBands(stdout)
   const bands = freqs.map((freqHz) => ({ freqHz, rmsDb: rms.get(freqHz) ?? -Infinity }))
   return detectCutoff(bands, nyquist)
+}
+
+// Reads the three figures we surface from ebur128's end-of-run Summary block.
+// ebur128 also prints a per-frame log line (each carrying its own "I:" and
+// "LRA:") for the whole track, and at t≈0 those read the -70 LUFS gate floor and
+// 0.0 LU — so we must parse the final "Summary:" block, not the first match, or a
+// perfectly loud track reports as near-silent. The "I:" / "Peak:" anchors are
+// unique to the integrated-loudness and true-peak rows; "LRA:" matches the
+// range value but not "LRA low/high:" (no colon right after "LRA"). A -inf
+// reading (silence) becomes -Infinity so the UI shows "−∞" instead of NaN.
+export function parseLoudness(
+  stderr: string,
+): Pick<LoudnessResult, 'integratedLufs' | 'truePeakDb' | 'lra'> | null {
+  const start = stderr.lastIndexOf('Summary:')
+  if (start === -1) return null
+  const summary = stderr.slice(start)
+  const num = (m: RegExpMatchArray | null): number | null =>
+    m ? (m[1] === '-inf' ? -Infinity : Number(m[1])) : null
+  const integratedLufs = num(summary.match(/\bI:\s*(-inf|-?[\d.]+)\s*LUFS/))
+  const truePeakDb = num(summary.match(/\bPeak:\s*(-inf|-?[\d.]+)\s*dBFS/))
+  const lra = num(summary.match(/\bLRA:\s*(-inf|-?[\d.]+)\s*LU\b/))
+  if (integratedLufs === null || truePeakDb === null || lra === null) return null
+  return { integratedLufs, truePeakDb, lra }
+}
+
+export interface AstatsResult {
+  balanceDb: number | null
+  dcOffset: number | null
+  crestDb: number | null
+  noiseFloorDb: number | null
+}
+
+// Pulls the channel checks out of astats' summary. Every line carries a
+// "[Parsed_astats_0 @ …]" prefix; sections are introduced by "Channel: N" and
+// "Overall". Per-channel RMS gives the L/R balance; the Overall block gives DC
+// offset, crest (peak − RMS) and the noise floor. ffmpeg can print "nan"/"-inf"
+// (e.g. a silent channel), so every value is finite-checked and a non-finite one
+// is dropped — the caller then hides that pill instead of showing "−∞"/"NaN".
+// Returns null only when there is no astats block at all.
+export function parseAstats(stderr: string): AstatsResult | null {
+  const finite = (s: string): number | null => {
+    const n = Number(s)
+    return Number.isFinite(n) ? n : null
+  }
+  const channelRms: number[] = []
+  const overall: { peak?: number; rms?: number; dc?: number; noise?: number } = {}
+  let section: 'channel' | 'overall' | null = null
+  let seen = false
+  for (const raw of stderr.split('\n')) {
+    const line = raw.replace(/^\[Parsed_astats[^\]]*\]\s*/, '').trim()
+    if (/^Channel:\s*\d+/.test(line)) {
+      section = 'channel'
+      seen = true
+    } else if (line === 'Overall') {
+      section = 'overall'
+      seen = true
+    } else if (section === 'channel') {
+      const m = line.match(/^RMS level dB:\s*(\S+)/)
+      if (m) {
+        const v = finite(m[1])
+        if (v !== null) channelRms.push(v)
+      }
+    } else if (section === 'overall') {
+      const peak = line.match(/^Peak level dB:\s*(\S+)/)
+      if (peak) overall.peak = finite(peak[1]) ?? undefined
+      const rms = line.match(/^RMS level dB:\s*(\S+)/)
+      if (rms) overall.rms = finite(rms[1]) ?? undefined
+      const dc = line.match(/^DC offset:\s*(\S+)/)
+      if (dc) {
+        const v = finite(dc[1])
+        if (v !== null) overall.dc = Math.abs(v)
+      }
+      const noise = line.match(/^Noise floor dB:\s*(\S+)/)
+      if (noise) overall.noise = finite(noise[1]) ?? undefined
+    }
+  }
+  if (!seen) return null
+  return {
+    // Both channels must be finite; a dropped (silent) channel leaves length < 2.
+    balanceDb: channelRms.length >= 2 ? Math.abs(channelRms[0] - channelRms[1]) : null,
+    dcOffset: overall.dc ?? null,
+    crestDb:
+      overall.peak !== undefined && overall.rms !== undefined ? overall.peak - overall.rms : null,
+    noiseFloorDb: overall.noise ?? null,
+  }
+}
+
+// Measures EBU R128 loudness and the per-channel checks (balance, DC offset) in a
+// single decode by chaining astats and ebur128 — both print their summary to
+// stderr at info level, so — unlike the other ffmpeg helpers — we must not pass
+// `-loglevel error`, or there would be nothing to parse; we mute only the periodic
+// progress lines with `-nostats`.
+export async function measureLoudness(input: string): Promise<LoudnessResult | null> {
+  const { stderr } = await run(
+    ffmpegPath,
+    [
+      '-hide_banner',
+      '-nostats',
+      '-i',
+      input,
+      '-af',
+      'astats=metadata=1:reset=0,ebur128=peak=true',
+      '-f',
+      'null',
+      '-',
+    ],
+    { maxBuffer: 1024 * 1024 * 16 },
+  )
+  const loud = parseLoudness(stderr)
+  if (!loud) return null
+  const stats = parseAstats(stderr)
+  return {
+    ...loud,
+    channelBalanceDb: stats?.balanceDb ?? null,
+    dcOffset: stats?.dcOffset ?? null,
+    crestDb: stats?.crestDb ?? null,
+    noiseFloorDb: stats?.noiseFloorDb ?? null,
+  }
 }
 
 interface SpectrumDeps {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -2,7 +2,17 @@ import { createReadStream, existsSync } from 'node:fs'
 import { copyFile, mkdir, stat } from 'node:fs/promises'
 import { basename, dirname, join } from 'node:path'
 import { Readable } from 'node:stream'
-import { app, BrowserWindow, dialog, ipcMain, Menu, nativeImage, protocol, shell } from 'electron'
+import {
+  app,
+  BrowserWindow,
+  clipboard,
+  dialog,
+  ipcMain,
+  Menu,
+  nativeImage,
+  protocol,
+  shell,
+} from 'electron'
 import log from 'electron-log/main'
 import electronUpdater from 'electron-updater'
 import { MEDIA_SCHEME, mediaMimeType, mediaPathFromUrl, parseRange } from '../shared/media'
@@ -23,6 +33,7 @@ import {
   convertAudio,
   extractCover,
   generateSpectrogram,
+  measureLoudness,
   probeAudio,
   probeDuration,
   readTags,
@@ -352,7 +363,14 @@ function registerIpc(): void {
       // Create the target's folder (and any subfolders the file-name template asks for)
       // before writing; recursive so it's a no-op when the directory already exists.
       await mkdir(dirname(target), { recursive: true })
-      await convertAudio(job.inputPath, target, format, job.meta, coverPath)
+      await convertAudio(
+        job.inputPath,
+        target,
+        format,
+        job.meta,
+        coverPath,
+        job.normalize ?? settings.normalize,
+      )
       if (inPlace) await removeRenamedOriginal(job.inputPath, target)
       recordConversion()
 
@@ -411,6 +429,10 @@ function registerIpc(): void {
   })
 
   ipcMain.handle('shell:reveal', (_e, path: string) => shell.showItemInFolder(path))
+  ipcMain.handle('shell:open', (_e, path: string) => shell.openPath(path))
+  // trashItem sends to the OS Trash / Recycle Bin (recoverable), never a hard delete.
+  ipcMain.handle('shell:trash', (_e, path: string) => shell.trashItem(path))
+  ipcMain.handle('clipboard:write', (_e, text: string) => clipboard.writeText(text))
 
   // Restarts into the already-downloaded update. Paired with the update:downloaded
   // push below — without this handler the toast's "Restart" button rejects.
@@ -447,6 +469,15 @@ function registerIpc(): void {
     } catch (err) {
       log.error('audio:spectrogram failed', err)
       throw err
+    }
+  })
+
+  ipcMain.handle('audio:loudness', async (_e, inputPath: string) => {
+    try {
+      return await measureLoudness(inputPath)
+    } catch (err) {
+      log.error('audio:loudness failed', err)
+      return null
     }
   })
 }

--- a/apps/desktop/src/main/inplace.ts
+++ b/apps/desktop/src/main/inplace.ts
@@ -11,7 +11,12 @@ import type { OutputFormat } from '../shared/types'
 export function sanitizeOutputName(name: string): string {
   return name
     .split('/')
-    .map((segment) => segment.replace(/[\\:*?"<>|]/g, '-').replace(/\s+/g, ' ').trim())
+    .map((segment) =>
+      segment
+        .replace(/[\\:*?"<>|]/g, '-')
+        .replace(/\s+/g, ' ')
+        .trim(),
+    )
     .filter(Boolean)
     .join('/')
 }

--- a/apps/desktop/src/main/normalize.test.ts
+++ b/apps/desktop/src/main/normalize.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest'
+import type { NormalizeConfig } from '../shared/types'
+import {
+  loudnormArgs,
+  loudnormFilter,
+  parseLoudnorm,
+  parseMaxVolume,
+  peakGainDb,
+  volumeFilter,
+} from './normalize'
+
+const loudness: NormalizeConfig = { mode: 'loudness', targetLufs: -14, truePeakDb: -1, peakDb: -1 }
+
+describe('parseLoudnorm', () => {
+  // loudnorm's first pass prints a JSON block to stderr, prefixed by the filter
+  // tag. We need the measured input_* values and the target_offset to feed the
+  // accurate (linear) second pass.
+  const out = `[Parsed_loudnorm_0 @ 0x1]\n{\n\t"input_i" : "-14.58",\n\t"input_tp" : "-0.16",\n\t"input_lra" : "6.60",\n\t"input_thresh" : "-24.79",\n\t"output_i" : "-13.93",\n\t"target_offset" : "-0.07"\n}`
+
+  it('reads the measured input figures and target offset from the JSON block', () => {
+    expect(parseLoudnorm(out)).toEqual({
+      inputI: -14.58,
+      inputTp: -0.16,
+      inputLra: 6.6,
+      inputThresh: -24.79,
+      targetOffset: -0.07,
+    })
+  })
+
+  it('returns null when no JSON is present (the measurement pass failed)', () => {
+    expect(parseLoudnorm('ffmpeg error, no json here')).toBeNull()
+  })
+
+  it('returns null when a figure is non-finite (e.g. -inf on silence) so we skip rather than feed garbage', () => {
+    const silent = out.replace('"input_i" : "-14.58"', '"input_i" : "-inf"')
+    expect(parseLoudnorm(silent)).toBeNull()
+  })
+})
+
+describe('loudnormFilter', () => {
+  it('builds the accurate second pass from the target plus the measured values', () => {
+    const f = loudnormFilter(loudness, {
+      inputI: -14.58,
+      inputTp: -0.16,
+      inputLra: 6.6,
+      inputThresh: -24.79,
+      targetOffset: -0.07,
+    })
+    expect(f).toContain('loudnorm=I=-14:TP=-1:LRA=11')
+    expect(f).toContain('measured_I=-14.58')
+    expect(f).toContain('measured_TP=-0.16')
+    expect(f).toContain('measured_thresh=-24.79')
+    expect(f).toContain('offset=-0.07')
+    // linear=true keeps the dynamics intact instead of pumping per-frame.
+    expect(f).toContain('linear=true')
+  })
+})
+
+describe('loudnormArgs', () => {
+  it('runs a measurement-only pass: the chosen target with json output to a null sink', () => {
+    const args = loudnormArgs('/in.aiff', loudness)
+    expect(args).toContain('/in.aiff')
+    expect(args.join(' ')).toContain('loudnorm=I=-14:TP=-1:LRA=11:print_format=json')
+    // measurement only: decode to a null muxer, no file written
+    expect(args.slice(-3)).toEqual(['-f', 'null', '-'])
+  })
+})
+
+describe('parseMaxVolume', () => {
+  it('reads the peak sample level volumedetect reports', () => {
+    expect(parseMaxVolume('[Parsed_volumedetect_0 @ 0x1] max_volume: -0.2 dB')).toBe(-0.2)
+  })
+
+  it('returns null when volumedetect printed nothing usable', () => {
+    expect(parseMaxVolume('no volume here')).toBeNull()
+  })
+})
+
+describe('peakGainDb', () => {
+  it('computes the gain that lifts the loudest sample to the target ceiling', () => {
+    // a track peaking at -6 dB, target -1 dB → boost +5 dB
+    expect(peakGainDb(-1, -6)).toBe(5)
+  })
+
+  it('attenuates when the track already peaks above the target', () => {
+    // peaking at +2 dB (clipping), target -1 → cut 3 dB
+    expect(peakGainDb(-1, 2)).toBe(-3)
+  })
+})
+
+describe('volumeFilter', () => {
+  it('renders the gain as an ffmpeg volume filter in dB', () => {
+    expect(volumeFilter(5)).toBe('volume=5dB')
+    expect(volumeFilter(-3.2)).toBe('volume=-3.2dB')
+  })
+})

--- a/apps/desktop/src/main/normalize.ts
+++ b/apps/desktop/src/main/normalize.ts
@@ -1,0 +1,88 @@
+import type { NormalizeConfig } from '../shared/types'
+
+// loudnorm's loudness range target. Kept fixed (the EBU R128 default) rather than
+// exposed as a knob — the user-facing choices are the integrated target and the
+// true-peak ceiling, which is plenty of control without inviting a bad LRA.
+const LOUDNORM_LRA = 11
+
+export interface LoudnormMeasured {
+  inputI: number
+  inputTp: number
+  inputLra: number
+  inputThresh: number
+  targetOffset: number
+}
+
+// First pass: measure the source so the second pass can normalize accurately
+// (linear) instead of the default dynamic mode that pumps frame-by-frame.
+export function loudnormArgs(input: string, cfg: NormalizeConfig): string[] {
+  return [
+    '-hide_banner',
+    '-nostats',
+    '-i',
+    input,
+    '-af',
+    `loudnorm=I=${cfg.targetLufs}:TP=${cfg.truePeakDb}:LRA=${LOUDNORM_LRA}:print_format=json`,
+    '-f',
+    'null',
+    '-',
+  ]
+}
+
+// Pulls the measured figures out of the JSON block loudnorm prints to stderr. Any
+// non-finite reading (e.g. "-inf" on near-silence) means we cannot build an
+// accurate pass, so we bail and skip normalization rather than feed garbage.
+export function parseLoudnorm(output: string): LoudnormMeasured | null {
+  const start = output.indexOf('{')
+  const end = output.lastIndexOf('}')
+  if (start === -1 || end <= start) return null
+  try {
+    const j = JSON.parse(output.slice(start, end + 1))
+    const m = {
+      inputI: Number(j.input_i),
+      inputTp: Number(j.input_tp),
+      inputLra: Number(j.input_lra),
+      inputThresh: Number(j.input_thresh),
+      targetOffset: Number(j.target_offset),
+    }
+    if (Object.values(m).some((v) => !Number.isFinite(v))) return null
+    return m
+  } catch {
+    return null
+  }
+}
+
+// Second pass: the chosen target plus the first pass's measurements, in linear
+// mode so the whole track is shifted by a constant gain (dynamics preserved).
+export function loudnormFilter(cfg: NormalizeConfig, m: LoudnormMeasured): string {
+  return [
+    `loudnorm=I=${cfg.targetLufs}`,
+    `TP=${cfg.truePeakDb}`,
+    `LRA=${LOUDNORM_LRA}`,
+    `measured_I=${m.inputI}`,
+    `measured_TP=${m.inputTp}`,
+    `measured_LRA=${m.inputLra}`,
+    `measured_thresh=${m.inputThresh}`,
+    `offset=${m.targetOffset}`,
+    'linear=true',
+  ].join(':')
+}
+
+// Peak mode: a single decode to find the loudest sample.
+export function volumedetectArgs(input: string): string[] {
+  return ['-hide_banner', '-nostats', '-i', input, '-af', 'volumedetect', '-f', 'null', '-']
+}
+
+export function parseMaxVolume(stderr: string): number | null {
+  const m = stderr.match(/max_volume:\s*(-?[\d.]+)\s*dB/)
+  return m ? Number(m[1]) : null
+}
+
+// The constant gain that moves the loudest sample to the target ceiling.
+export function peakGainDb(targetDb: number, maxVolumeDb: number): number {
+  return targetDb - maxVolumeDb
+}
+
+export function volumeFilter(gainDb: number): string {
+  return `volume=${gainDb}dB`
+}

--- a/apps/desktop/src/main/settings.ts
+++ b/apps/desktop/src/main/settings.ts
@@ -19,6 +19,9 @@ const defaults: Settings = {
   coverMaxSize: 1200,
   coverSquare: false,
   showSpectrum: true,
+  showLoudness: true,
+  // Off by default: a conversion never changes loudness unless the user enables it.
+  normalize: { mode: 'none', targetLufs: -14, truePeakDb: -1, peakDb: -1 },
   hasSeenOnboarding: false,
   conversionCount: 0,
 }

--- a/apps/desktop/src/main/tags.test.ts
+++ b/apps/desktop/src/main/tags.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
   Id3v2FrameClassType,
+  Id3v2FrameIdentifiers,
   type Id3v2Tag,
   Id3v2UserTextInformationFrame,
   File as TagFile,
@@ -10,7 +11,16 @@ import {
 } from 'node-taglib-sharp'
 import { describe, expect, it } from 'vitest'
 import type { TrackMetadata } from '../shared/types'
-import { preservesCuesInPlace, writeTags } from './tags'
+import { copyCueFrames, preservesCuesInPlace, writeTags } from './tags'
+
+// Strips the GEOB cue frame from a file, to model the output of a normalizing
+// ffmpeg re-encode (which drops it) before copyCueFrames puts it back.
+function stripCues(file: string): void {
+  const f = TagFile.createFromPath(file)
+  ;(f.getTag(TagTypes.Id3v2, true) as Id3v2Tag).removeFrames(Id3v2FrameIdentifiers.GEOB)
+  f.save()
+  f.dispose()
+}
 
 const meta: TrackMetadata = {
   title: 'Till I Come',
@@ -163,5 +173,36 @@ describe('writeTags', () => {
     const f = TagFile.createFromPath(file)
     expect(f.tag.comment).toBeFalsy()
     f.dispose()
+  })
+})
+
+describe('copyCueFrames', () => {
+  // Normalizing re-encodes the audio (ffmpeg drops the GEOB), but a constant gain
+  // never moves the cues in time — so re-injecting the source's frame restores them
+  // exactly. This is what keeps Traktor cues through a normalizing convert.
+  it('re-injects the source GEOB cue frame into an output that lost it', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'surco-tags-'))
+    const source = buildSeed(dir)
+    const out = join(dir, 'normalized.mp3')
+    writeFileSync(out, readFileSync(source))
+    stripCues(out)
+    expect(readFileSync(out).includes(Buffer.from('TRAKTORCUEBLOB'))).toBe(false)
+
+    copyCueFrames(source, out)
+
+    const bytes = readFileSync(out)
+    expect(bytes.includes(Buffer.from('TRAKTOR4'))).toBe(true)
+    expect(bytes.includes(Buffer.from('TRAKTORCUEBLOB'))).toBe(true)
+  })
+
+  it('leaves the output untouched when the source carries no cue frame', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'surco-tags-'))
+    const source = buildSeed(dir)
+    stripCues(source)
+    const out = join(dir, 'normalized.mp3')
+    writeFileSync(out, readFileSync(source))
+
+    expect(() => copyCueFrames(source, out)).not.toThrow()
+    expect(readFileSync(out).includes(Buffer.from('TRAKTORCUEBLOB'))).toBe(false)
   })
 })

--- a/apps/desktop/src/main/tags.ts
+++ b/apps/desktop/src/main/tags.ts
@@ -1,6 +1,7 @@
 import { extname } from 'node:path'
 import {
   Id3v2AttachmentFrame,
+  type Id3v2Frame,
   Id3v2FrameClassType,
   Id3v2FrameIdentifiers,
   type Id3v2Tag,
@@ -26,6 +27,40 @@ const ID3_IN_PLACE = new Set(['.mp3', '.aiff'])
 
 export function preservesCuesInPlace(ext: string): boolean {
   return ID3_IN_PLACE.has(ext.toLowerCase())
+}
+
+// Carries Traktor's GEOB cue/beatgrid frame from a source file into a freshly
+// converted one. Normalizing re-encodes the audio through ffmpeg, which drops the
+// frame — but a constant gain never shifts the cues in time, so copying the frame
+// verbatim restores them exactly. GEOB is copied as a whole frame (via clone) and
+// never parsed: its body is an opaque Traktor blob that TagLib's attachment parser
+// can choke on. Best-effort — any failure leaves the (already valid) output as-is
+// rather than aborting the conversion. Only meaningful for ID3 containers.
+export function copyCueFrames(source: string, dest: string): void {
+  try {
+    const src = TagFile.createFromPath(source)
+    let cues: Id3v2Frame[]
+    try {
+      const tag = src.getTag(TagTypes.Id3v2, false) as Id3v2Tag | null
+      const geob = tag?.frames.filter((fr) => fr.frameId.toString() === 'GEOB') ?? []
+      cues = geob.map((fr) => fr.clone())
+    } finally {
+      src.dispose()
+    }
+    if (cues.length === 0) return
+
+    const out = TagFile.createFromPath(dest)
+    try {
+      const tag = out.getTag(TagTypes.Id3v2, true) as Id3v2Tag
+      tag.removeFrames(Id3v2FrameIdentifiers.GEOB)
+      for (const frame of cues) tag.addFrame(frame)
+      out.save()
+    } finally {
+      out.dispose()
+    }
+  } catch {
+    // Cue preservation is a bonus; never let it break a successful conversion.
+  }
 }
 
 const toNumber = (value: string): number => {

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -4,6 +4,7 @@ import type {
   DiscogsRelease,
   DiscogsSearchResult,
   ProcessJob,
+  LoudnessResult,
   ProcessProgress,
   ProcessResult,
   SearchProviderId,
@@ -30,7 +31,11 @@ export interface Api {
   prepareCoverDrag: (src: { coverUrl?: string; coverPath?: string }) => Promise<string | null>
   startCoverDrag: (path: string) => void
   reveal: (path: string) => Promise<void>
+  openFile: (path: string) => Promise<string>
+  trashFile: (path: string) => Promise<void>
+  copyText: (text: string) => Promise<void>
   spectrogram: (path: string) => Promise<SpectrumResult>
+  loudness: (path: string) => Promise<LoudnessResult | null>
   readTags: (path: string) => Promise<TrackMetadata>
   readDuration: (path: string) => Promise<number | null>
   readCover: (path: string) => Promise<string | null>

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -1,5 +1,5 @@
 import { contextBridge, ipcRenderer, webUtils } from 'electron'
-import type { ProcessProgress, SearchProviderId } from '../shared/types'
+import type { LoudnessResult, ProcessProgress, SearchProviderId } from '../shared/types'
 
 const api = {
   platform: process.platform,
@@ -25,7 +25,12 @@ const api = {
     ipcRenderer.invoke('cover:prepareDrag', src),
   startCoverDrag: (path: string): void => ipcRenderer.send('cover:drag', path),
   reveal: (path: string) => ipcRenderer.invoke('shell:reveal', path),
+  openFile: (path: string): Promise<string> => ipcRenderer.invoke('shell:open', path),
+  trashFile: (path: string): Promise<void> => ipcRenderer.invoke('shell:trash', path),
+  copyText: (text: string): Promise<void> => ipcRenderer.invoke('clipboard:write', text),
   spectrogram: (path: string) => ipcRenderer.invoke('audio:spectrogram', path),
+  loudness: (path: string): Promise<LoudnessResult | null> =>
+    ipcRenderer.invoke('audio:loudness', path),
   readTags: (path: string) => ipcRenderer.invoke('audio:tags', path),
   readDuration: (path: string) => ipcRenderer.invoke('audio:duration', path),
   readCover: (path: string) => ipcRenderer.invoke('audio:cover', path),

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -2,7 +2,13 @@ import type React from 'react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { mediaUrl } from '../../shared/media'
-import type { OutputFormat, Settings, ThemePref, TrackMetadata } from '../../shared/types'
+import type {
+  NormalizeConfig,
+  OutputFormat,
+  Settings,
+  ThemePref,
+  TrackMetadata,
+} from '../../shared/types'
 import { CommandPalette } from './components/CommandPalette'
 import { ConfirmDialog } from './components/ConfirmDialog'
 import { Editor } from './components/Editor'
@@ -141,6 +147,9 @@ export default function App(): React.JSX.Element {
   // shortcuts export in it too. Null means "untouched" — fall back to the Settings
   // default. Reset on track switch, matching the editor reseeding per track.
   const editorFormatRef = useRef<OutputFormat | null>(null)
+  // Per-track normalization override picked in the editor; null falls back to the
+  // Settings default at conversion time, mirroring editorFormatRef.
+  const editorNormalizeRef = useRef<NormalizeConfig | null>(null)
 
   useEffect(() => {
     window.api.getSettings().then((s) => {
@@ -237,6 +246,7 @@ export default function App(): React.JSX.Element {
   // biome-ignore lint/correctness/useExhaustiveDependencies: selectedId is the deliberate trigger, not a value read in the body — the reset must fire on every track switch.
   useEffect(() => {
     editorFormatRef.current = null
+    editorNormalizeRef.current = null
   }, [selectedId])
 
   async function pickFiles(): Promise<void> {
@@ -328,6 +338,36 @@ export default function App(): React.JSX.Element {
     discogsPrefetched.current.clear()
   }
 
+  // Right-click "Search Discogs": make the track active, then focus the search box on the
+  // next tick once the editor for the new selection has mounted and bound the ref.
+  const onSearchTrack = useCallback(
+    (id: string): void => {
+      onSelectTrack(id, {})
+      setTimeout(() => searchInputRef.current?.focus(), 0)
+    },
+    [onSelectTrack],
+  )
+
+  // Right-click "Move to Trash": confirm first, then send the original file to the OS
+  // Trash/Recycle Bin and drop the row only once that succeeds, so a failure leaves the
+  // list untouched. Copy switches on platform because the destination differs.
+  function askTrash(track: TrackItem): void {
+    const isWin = window.api.platform === 'win32'
+    setConfirm({
+      title: tr(isWin ? 'confirm.trashTitleWin' : 'confirm.trashTitle'),
+      message: tr(isWin ? 'confirm.trashMessageWin' : 'confirm.trashMessage', {
+        name: track.fileName,
+      }),
+      confirmLabel: tr(isWin ? 'confirm.trashConfirmWin' : 'confirm.trashConfirm'),
+      onConfirm: () => {
+        window.api
+          .trashFile(track.inputPath)
+          .then(() => removeTrack(track.id))
+          .catch(() => {})
+      },
+    })
+  }
+
   function selectAll(): void {
     if (tracks.length === 0) return
     setSelection({ ids: tracks.map((t) => t.id), anchor: tracks[0].id })
@@ -404,7 +444,11 @@ export default function App(): React.JSX.Element {
     if (playerVisible && selected && selected.id !== playingIdRef.current) startPlayback(selected)
   }, [selectedId, playerVisible, startPlayback])
 
-  async function processOne(id: string, formatOverride?: OutputFormat): Promise<BatchOutcome> {
+  async function processOne(
+    id: string,
+    formatOverride?: OutputFormat,
+    normalizeOverride?: NormalizeConfig,
+  ): Promise<BatchOutcome> {
     const track = tracks.find((t) => t.id === id)
     if (!track) return 'failed'
     const missing = missingRequired(track.meta, settings?.requiredFields ?? DEFAULT_REQUIRED_FIELDS)
@@ -444,6 +488,7 @@ export default function App(): React.JSX.Element {
         coverUrl: track.coverUrl,
         coverPath: track.coverPath,
         format: formatOverride,
+        normalize: normalizeOverride,
         previousOutputPath: track.outputPath,
       })
       // The user declined to overwrite a conflicting file: nothing was written, so
@@ -499,7 +544,10 @@ export default function App(): React.JSX.Element {
     for (const id of ids) await addTrackToAppleMusic(id)
   }
 
-  async function processAll(formatOverride?: OutputFormat): Promise<void> {
+  async function processAll(
+    formatOverride?: OutputFormat,
+    normalizeOverride?: NormalizeConfig,
+  ): Promise<void> {
     if (batching) return
     const ids = eligibleForBatch(tracks)
     cancelBatchRef.current = false
@@ -512,7 +560,7 @@ export default function App(): React.JSX.Element {
         // Cancel stops the loop before the next track; the one already converting
         // in the main process can't be aborted, so it finishes and is counted.
         if (cancelBatchRef.current) break
-        results.push(await processOne(id, formatOverride))
+        results.push(await processOne(id, formatOverride, normalizeOverride))
         setBatchProgress({ done: results.length, total: ids.length })
       }
     } finally {
@@ -609,14 +657,21 @@ export default function App(): React.JSX.Element {
       title: tr('commands.processCurrent'),
       hint: formatShortcut(['mod', 'enter'], isMac),
       enabled: canProcessSelected,
-      run: () => selected && processOne(selected.id, editorFormatRef.current ?? undefined),
+      run: () =>
+        selected &&
+        processOne(
+          selected.id,
+          editorFormatRef.current ?? undefined,
+          editorNormalizeRef.current ?? undefined,
+        ),
     },
     {
       id: 'process-all',
       title: tr('commands.processAll'),
       hint: formatShortcut(['mod', 'shift', 'enter'], isMac),
       enabled: canProcessAll,
-      run: () => processAll(editorFormatRef.current ?? undefined),
+      run: () =>
+        processAll(editorFormatRef.current ?? undefined, editorNormalizeRef.current ?? undefined),
     },
     {
       id: 'reveal',
@@ -968,6 +1023,8 @@ export default function App(): React.JSX.Element {
                 onSelect={onSelectTrack}
                 onRemove={removeTrack}
                 onPrefetch={handlePrefetch}
+                onSearch={onSearchTrack}
+                onTrash={askTrash}
               />
             )}
           </div>
@@ -991,20 +1048,31 @@ export default function App(): React.JSX.Element {
               visibleFields={settings?.visibleFields ?? DEFAULT_FIELDS}
               requiredFields={settings?.requiredFields ?? DEFAULT_REQUIRED_FIELDS}
               showSpectrum={settings?.showSpectrum ?? true}
+              showLoudness={settings?.showLoudness ?? true}
+              normalize={
+                settings?.normalize ?? { mode: 'none', targetLufs: -14, truePeakDb: -1, peakDb: -1 }
+              }
               searchInputRef={searchInputRef}
               selectedTracks={selectedTracks}
               onApplyMatches={(patches) => {
                 for (const p of patches) updateTrack(p.id, p.patch)
               }}
-              onProcessAll={processAll}
+              onProcessAll={(format) => processAll(format, editorNormalizeRef.current ?? undefined)}
               onAddAllToAppleMusic={() => addAllToAppleMusic(selectedIds)}
               onChangeAllMeta={(patch) => updateTracksMeta(selectedIds, patch)}
-              onApplyCoverAll={(coverUrl, coverPath) => patchTracks(selectedIds, { coverUrl, coverPath })}
+              onApplyCoverAll={(coverUrl, coverPath) =>
+                patchTracks(selectedIds, { coverUrl, coverPath })
+              }
               onDeriveTags={deriveTracks}
               onChange={(patch) => updateTrack(selected.id, patch)}
-              onProcess={(format) => processOne(selected.id, format)}
+              onProcess={(format) =>
+                processOne(selected.id, format, editorNormalizeRef.current ?? undefined)
+              }
               onFormatChange={(format) => {
                 editorFormatRef.current = format
+              }}
+              onNormalizeChange={(n) => {
+                editorNormalizeRef.current = n
               }}
               onAddToAppleMusic={() => addTrackToAppleMusic(selected.id)}
               onOpenSettings={() => openSettings()}

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -993,7 +993,9 @@ export default function App(): React.JSX.Element {
               showSpectrum={settings?.showSpectrum ?? true}
               searchInputRef={searchInputRef}
               selectedTracks={selectedTracks}
-              onApplyMatches={(patches) => patches.forEach((p) => updateTrack(p.id, p.patch))}
+              onApplyMatches={(patches) => {
+                for (const p of patches) updateTrack(p.id, p.patch)
+              }}
               onProcessAll={processAll}
               onAddAllToAppleMusic={() => addAllToAppleMusic(selectedIds)}
               onChangeAllMeta={(patch) => updateTracksMeta(selectedIds, patch)}

--- a/apps/desktop/src/renderer/src/components/AlbumMatchRows.tsx
+++ b/apps/desktop/src/renderer/src/components/AlbumMatchRows.tsx
@@ -108,6 +108,7 @@ export function AlbumMatchRows({ files, release, onApply }: Props): React.JSX.El
                 >
                   <option value="">{tr('match.unassigned')}</option>
                   {release.tracklist.map((track, i) => (
+                    // biome-ignore lint/suspicious/noArrayIndexKey: the index is the option's value (used to index tracklist) on a static, non-reordered list
                     <option key={`${track.position}-${track.title}-${i}`} value={String(i)}>
                       {[track.position, track.title].filter(Boolean).join(' ')}
                       {track.duration ? ` (${track.duration})` : ''}

--- a/apps/desktop/src/renderer/src/components/Editor.test.tsx
+++ b/apps/desktop/src/renderer/src/components/Editor.test.tsx
@@ -4,7 +4,7 @@ import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { createRef, useState } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import i18n from '../i18n'
-import type { OutputFormat, TrackMetadata } from '../../../shared/types'
+import type { NormalizeConfig, OutputFormat, TrackMetadata } from '../../../shared/types'
 import type { TrackItem } from '../types'
 import { Editor } from './Editor'
 
@@ -53,7 +53,12 @@ function item(
 function renderEditor(
   over: Partial<Omit<TrackItem, 'meta'>> & { id: string; meta?: Partial<TrackMetadata> },
   outputFormat: OutputFormat = 'wav',
-  props: { requiredFields?: string[]; visibleFields?: string[]; showLoudness?: boolean } = {},
+  props: {
+    requiredFields?: string[]
+    visibleFields?: string[]
+    showLoudness?: boolean
+    normalize?: NormalizeConfig
+  } = {},
 ): {
   onProcess: ReturnType<typeof vi.fn>
   onChange: ReturnType<typeof vi.fn>
@@ -76,7 +81,7 @@ function renderEditor(
       requiredFields={props.requiredFields ?? []}
       showSpectrum={false}
       showLoudness={props.showLoudness ?? false}
-      normalize={{ mode: 'none', targetLufs: -14, truePeakDb: -1, peakDb: -1 }}
+      normalize={props.normalize ?? { mode: 'none', targetLufs: -14, truePeakDb: -1, peakDb: -1 }}
       searchInputRef={createRef<HTMLInputElement>()}
       onChange={onChange}
       onProcess={onProcess}
@@ -113,6 +118,23 @@ describe('Editor derive from filename', () => {
     expect(onDeriveTags).toHaveBeenCalledWith([
       { id: 'a', meta: { trackNumber: '104', artist: 'kumara', title: 'snap' } },
     ])
+  })
+})
+
+describe('Editor convert button normalization note', () => {
+  // Normalization must be visible at the moment of converting, not just buried in a
+  // folded section — otherwise the user can't tell the export will alter loudness.
+  it('flags the active normalization above the convert button', () => {
+    renderEditor({ id: 'a' }, 'wav', {
+      normalize: { mode: 'loudness', targetLufs: -14, truePeakDb: -1, peakDb: -1 },
+    })
+    const note = screen.getByTestId('convert-normalize-note')
+    expect(note).toHaveTextContent('-14')
+  })
+
+  it('shows no note when normalization is off', () => {
+    renderEditor({ id: 'a' }, 'wav')
+    expect(screen.queryByTestId('convert-normalize-note')).toBeNull()
   })
 })
 

--- a/apps/desktop/src/renderer/src/components/Editor.test.tsx
+++ b/apps/desktop/src/renderer/src/components/Editor.test.tsx
@@ -53,7 +53,7 @@ function item(
 function renderEditor(
   over: Partial<Omit<TrackItem, 'meta'>> & { id: string; meta?: Partial<TrackMetadata> },
   outputFormat: OutputFormat = 'wav',
-  props: { requiredFields?: string[]; visibleFields?: string[] } = {},
+  props: { requiredFields?: string[]; visibleFields?: string[]; showLoudness?: boolean } = {},
 ): {
   onProcess: ReturnType<typeof vi.fn>
   onChange: ReturnType<typeof vi.fn>
@@ -75,6 +75,8 @@ function renderEditor(
       visibleFields={props.visibleFields ?? []}
       requiredFields={props.requiredFields ?? []}
       showSpectrum={false}
+      showLoudness={props.showLoudness ?? false}
+      normalize={{ mode: 'none', targetLufs: -14, truePeakDb: -1, peakDb: -1 }}
       searchInputRef={createRef<HTMLInputElement>()}
       onChange={onChange}
       onProcess={onProcess}
@@ -114,6 +116,131 @@ describe('Editor derive from filename', () => {
   })
 })
 
+describe('Editor loudness pills', () => {
+  // The whole point of the colour is that a non-technical user reads the verdict
+  // without understanding LUFS/dBTP/LU: a near-silent, clipping, flat track is
+  // wrong on all three counts and must read red across the board.
+  it('grades a near-silent, clipping, flat track as bad on every pill', () => {
+    renderEditor(
+      {
+        id: 'a',
+        loudness: {
+          integratedLufs: -70,
+          truePeakDb: 2.5,
+          lra: 0,
+          channelBalanceDb: 6,
+          dcOffset: 0.03,
+          crestDb: 5,
+          noiseFloorDb: -20,
+        },
+      },
+      'wav',
+      { showLoudness: true },
+    )
+    expect(screen.getByTestId('loudness-pill-lufs')).toHaveAttribute('data-grade', 'bad')
+    expect(screen.getByTestId('loudness-pill-peak')).toHaveAttribute('data-grade', 'bad')
+    expect(screen.getByTestId('loudness-pill-range')).toHaveAttribute('data-grade', 'bad')
+    expect(screen.getByTestId('loudness-pill-crest')).toHaveAttribute('data-grade', 'bad')
+    expect(screen.getByTestId('loudness-pill-balance')).toHaveAttribute('data-grade', 'bad')
+    expect(screen.getByTestId('loudness-pill-dc')).toHaveAttribute('data-grade', 'bad')
+    expect(screen.getByTestId('loudness-pill-noise')).toHaveAttribute('data-grade', 'bad')
+  })
+
+  it('grades a healthy track green on every pill', () => {
+    renderEditor(
+      {
+        id: 'a',
+        loudness: {
+          integratedLufs: -12,
+          truePeakDb: -1.5,
+          lra: 8,
+          channelBalanceDb: 0.5,
+          dcOffset: 0.0001,
+          crestDb: 16,
+          noiseFloorDb: -55,
+        },
+      },
+      'wav',
+      { showLoudness: true },
+    )
+    expect(screen.getByTestId('loudness-pill-lufs')).toHaveAttribute('data-grade', 'good')
+    expect(screen.getByTestId('loudness-pill-peak')).toHaveAttribute('data-grade', 'good')
+    expect(screen.getByTestId('loudness-pill-range')).toHaveAttribute('data-grade', 'good')
+    expect(screen.getByTestId('loudness-pill-crest')).toHaveAttribute('data-grade', 'good')
+    expect(screen.getByTestId('loudness-pill-balance')).toHaveAttribute('data-grade', 'good')
+    expect(screen.getByTestId('loudness-pill-dc')).toHaveAttribute('data-grade', 'good')
+    expect(screen.getByTestId('loudness-pill-noise')).toHaveAttribute('data-grade', 'good')
+  })
+
+  it('drops the balance pill for a mono rip, where there is no left/right to compare', () => {
+    renderEditor(
+      {
+        id: 'a',
+        loudness: {
+          integratedLufs: -12,
+          truePeakDb: -1.5,
+          lra: 8,
+          channelBalanceDb: null,
+          dcOffset: 0.0001,
+          crestDb: 16,
+          noiseFloorDb: -55,
+        },
+      },
+      'wav',
+      { showLoudness: true },
+    )
+    expect(screen.queryByTestId('loudness-pill-balance')).toBeNull()
+    expect(screen.getByTestId('loudness-pill-dc')).toBeInTheDocument()
+  })
+
+  // The figures need explaining once, but must not clutter the panel on every edit,
+  // so the explanation stays hidden until the user asks for it.
+  it('reveals the explanation only when the help button is pressed', () => {
+    renderEditor(
+      {
+        id: 'a',
+        loudness: {
+          integratedLufs: -12,
+          truePeakDb: -1.5,
+          lra: 8,
+          channelBalanceDb: 0.5,
+          dcOffset: 0.0001,
+          crestDb: 16,
+          noiseFloorDb: -55,
+        },
+      },
+      'wav',
+      { showLoudness: true },
+    )
+    expect(screen.queryByTestId('loudness-help')).toBeNull()
+    fireEvent.click(screen.getByTestId('loudness-help-toggle'))
+    expect(screen.getByTestId('loudness-help')).toBeInTheDocument()
+  })
+
+  it('closes the help modal on Escape, the expected way to dismiss a dialog', () => {
+    renderEditor(
+      {
+        id: 'a',
+        loudness: {
+          integratedLufs: -12,
+          truePeakDb: -1.5,
+          lra: 8,
+          channelBalanceDb: 0.5,
+          dcOffset: 0.0001,
+          crestDb: 16,
+          noiseFloorDb: -55,
+        },
+      },
+      'wav',
+      { showLoudness: true },
+    )
+    fireEvent.click(screen.getByTestId('loudness-help-toggle'))
+    expect(screen.getByTestId('loudness-help')).toBeInTheDocument()
+    fireEvent.keyDown(document.body, { key: 'Escape' })
+    expect(screen.queryByTestId('loudness-help')).toBeNull()
+  })
+})
+
 // Mirrors App's real wiring (tracks in state, updateTracksMeta over the selection) so a
 // reported bug — editing one shared field, then another, only saving the first — can be
 // reproduced or ruled out as a logic problem rather than a focus/UI one.
@@ -142,6 +269,8 @@ function MultiHarness() {
         visibleFields={['title', 'album']}
         requiredFields={[]}
         showSpectrum={false}
+        showLoudness={false}
+        normalize={{ mode: 'none', targetLufs: -14, truePeakDb: -1, peakDb: -1 }}
         searchInputRef={createRef<HTMLInputElement>()}
         selectedTracks={selectedTracks}
         onApplyMatches={vi.fn()}
@@ -174,7 +303,8 @@ describe('Editor multi-select sequential edits', () => {
 
 describe('Editor multi-select', () => {
   function renderMulti(opts: { done?: boolean; platform?: string; music?: boolean } = {}) {
-    if (opts.platform) (window as unknown as { api: { platform: string } }).api.platform = opts.platform
+    if (opts.platform)
+      (window as unknown as { api: { platform: string } }).api.platform = opts.platform
     const onChangeAllMeta = vi.fn()
     const onProcessAll = vi.fn()
     const onAddAllToAppleMusic = vi.fn()
@@ -206,6 +336,8 @@ describe('Editor multi-select', () => {
         visibleFields={['title', 'album']}
         requiredFields={[]}
         showSpectrum
+        showLoudness={false}
+        normalize={{ mode: 'none', targetLufs: -14, truePeakDb: -1, peakDb: -1 }}
         searchInputRef={createRef<HTMLInputElement>()}
         selectedTracks={[a, b]}
         onApplyMatches={vi.fn()}
@@ -339,7 +471,10 @@ describe('Editor output file name', () => {
   // Users complained that loading a file and converting renamed it from metadata.
   // The field must default to the source file's own name, leaving any rename opt-in.
   it('defaults the output name to the original file name, not the metadata', () => {
-    renderEditor({ id: 'a', fileName: 'original track 01', meta: { artist: 'AR', title: 'TI' } }, 'wav')
+    renderEditor(
+      { id: 'a', fileName: 'original track 01', meta: { artist: 'AR', title: 'TI' } },
+      'wav',
+    )
     expect(screen.getByTestId('output-name')).toHaveValue('original track 01')
   })
 

--- a/apps/desktop/src/renderer/src/components/Editor.tsx
+++ b/apps/desktop/src/renderer/src/components/Editor.tsx
@@ -274,7 +274,7 @@ export function Editor({
   }
 
   function applyImageFile(file: File | undefined): void {
-    if (!file || !file.type.startsWith('image/')) return
+    if (!file?.type.startsWith('image/')) return
     const coverUrl = URL.createObjectURL(file)
     const coverPath = window.api.getPathForFile(file)
     if (isMulti) onApplyCoverAll?.(coverUrl, coverPath)

--- a/apps/desktop/src/renderer/src/components/Editor.tsx
+++ b/apps/desktop/src/renderer/src/components/Editor.tsx
@@ -5,6 +5,7 @@ import type {
   DiscogsRelease,
   DiscogsSearchResult,
   DiscogsTrack,
+  NormalizeConfig,
   OutputFormat,
   TrackMetadata,
 } from '../../../shared/types'
@@ -17,7 +18,20 @@ import { FIELD_DEFS, missingRequired } from '../lib/fields'
 import { genrePresets } from '../lib/genre'
 import { smartDeriveTags } from '../lib/deriveTags'
 import { renderOutputName } from '../lib/outputName'
-import { formatKHz, qualityVerdict } from '../lib/quality'
+import {
+  formatDb,
+  formatKHz,
+  formatPercent,
+  type Grade,
+  gradeBalance,
+  gradeCrest,
+  gradeDcOffset,
+  gradeLra,
+  gradeLufs,
+  gradeNoiseFloor,
+  gradeTruePeak,
+  qualityVerdict,
+} from '../lib/quality'
 import {
   bestMatch,
   buildReleaseMeta,
@@ -28,11 +42,27 @@ import {
 import { parseReleaseId } from '../lib/search'
 import type { TrackItem } from '../types'
 import { AlbumMatchRows } from './AlbumMatchRows'
+import { LoudnessHelpModal } from './LoudnessHelpModal'
+import { NormalizeControls } from './NormalizeControls'
 import { ResizeHandle, useResizableWidth } from './ResizeHandle'
 import { Spectrogram } from './Spectrogram'
 import { WaveSpinner } from './WaveSpinner'
 
 const FORMATS: OutputFormat[] = ['aiff', 'mp3', 'wav', 'flac']
+
+// Per-grade colour for the analysis stat cells, reusing the good/warn/danger
+// tokens (Tokyo Night). The dot is a solid status light; the value text carries
+// the same colour so the verdict reads at a glance.
+const GRADE_DOT: Record<Grade, string> = {
+  good: 'bg-good',
+  warn: 'bg-warn',
+  bad: 'bg-danger',
+}
+const GRADE_TEXT: Record<Grade, string> = {
+  good: 'text-good',
+  warn: 'text-warn',
+  bad: 'text-danger',
+}
 
 interface Props {
   item: TrackItem
@@ -44,6 +74,9 @@ interface Props {
   visibleFields: string[]
   requiredFields: string[]
   showSpectrum: boolean
+  showLoudness: boolean
+  // The Settings normalization default, seeding the per-track override control.
+  normalize: NormalizeConfig
   searchInputRef: React.RefObject<HTMLInputElement | null>
   // The whole multi-selection, when more than one track is picked. Its presence flips the
   // Discogs column to album-match mode (map every file to a tracklist entry at once) and
@@ -65,6 +98,9 @@ interface Props {
   // Reports the format chosen in the split-button menu so the keyboard convert
   // shortcuts (⌘⏎ / ⌘⇧⏎) export in it too, instead of the Settings default.
   onFormatChange?: (format: OutputFormat) => void
+  // Reports the per-track normalization override so the keyboard convert shortcuts
+  // and "convert all" apply it too, mirroring onFormatChange.
+  onNormalizeChange?: (normalize: NormalizeConfig) => void
   onAddToAppleMusic: () => void
   onOpenSettings: () => void
 }
@@ -79,6 +115,8 @@ export function Editor({
   visibleFields,
   requiredFields,
   showSpectrum,
+  showLoudness,
+  normalize,
   searchInputRef,
   selectedTracks,
   onApplyMatches,
@@ -90,6 +128,7 @@ export function Editor({
   onChange,
   onProcess,
   onFormatChange,
+  onNormalizeChange,
   onAddToAppleMusic,
   onOpenSettings,
 }: Props): React.JSX.Element {
@@ -113,12 +152,21 @@ export function Editor({
   const [analyzeError, setAnalyzeError] = useState('')
   const [formOpen, setFormOpen] = useState(true)
   const [spectrumOpen, setSpectrumOpen] = useState(true)
+  // The loudness help is hidden by default and toggled by the ⓘ button: the
+  // figures need explaining once, but shouldn't clutter the panel on every edit.
+  const [loudnessHelpOpen, setLoudnessHelpOpen] = useState(false)
   const [outputOpen, setOutputOpen] = useState(true)
+  // Normalization is off by default and most users won't touch it, so its section
+  // starts folded — unlike the always-on Metadata/Quality/File name sections.
+  const [normalizeOpen, setNormalizeOpen] = useState(false)
   // The chosen export format, seeded from the Settings default. The format menu
   // only updates this; conversion waits for a deliberate click on the main button.
   // The Editor remounts per track (key={track.id}), so each track starts from the
   // default rather than inheriting the last track's pick.
   const [format, setFormat] = useState(outputFormat)
+  // Per-track normalization, seeded from the Settings default. Editing it both
+  // updates the control and reports the override up so convert uses it.
+  const [normalizeCfg, setNormalizeCfg] = useState(normalize)
   const [inLibrary, setInLibrary] = useState<'idle' | 'yes' | 'no'>('idle')
   const releaseRef = useRef<DiscogsRelease | null>(null)
   const coverDragPath = useRef<string | null>(null)
@@ -190,6 +238,23 @@ export function Editor({
       active = false
     }
   }, [item.inputPath, showSpectrum])
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: same once-per-input rule as the spectrum effect above — the Editor remounts per track (key={track.id}), so keying on inputPath measures exactly once; showLoudness is included so enabling the readout later measures the current track instead of waiting for a track switch. item.loudness is intentionally not a dependency: a finished measurement (including a null failure) must not retrigger it.
+  useEffect(() => {
+    if (!showLoudness || item.loudness !== undefined) return
+    let active = true
+    window.api
+      .loudness(item.inputPath)
+      .then((res) => {
+        if (active) onChange({ loudness: res })
+      })
+      .catch(() => {
+        if (active) onChange({ loudness: null })
+      })
+    return () => {
+      active = false
+    }
+  }, [item.inputPath, showLoudness])
 
   // Checking whether the song is already in the Apple Music library is a hint to
   // avoid duplicating tracks, so it tracks the live title/artist (debounced —
@@ -307,10 +372,14 @@ export function Editor({
   // aggregate values: the block shows once every selected track is converted, reveal
   // opens the first output, and the Apple Music button reflects the whole selection.
   const multiTracks = selectedTracks ?? []
-  const showDone = isMulti ? multiTracks.length > 0 && multiTracks.every((t) => t.status === 'done') : done
+  const showDone = isMulti
+    ? multiTracks.length > 0 && multiTracks.every((t) => t.status === 'done')
+    : done
   const revealPath = isMulti ? multiTracks.find((t) => t.outputPath)?.outputPath : item.outputPath
   const musicExt = isMulti ? format : exportedFormat
-  const musicAdding = isMulti ? multiTracks.some((t) => t.musicStatus === 'adding') : item.musicStatus === 'adding'
+  const musicAdding = isMulti
+    ? multiTracks.some((t) => t.musicStatus === 'adding')
+    : item.musicStatus === 'adding'
   const musicAdded = isMulti
     ? multiTracks.length > 0 && multiTracks.every((t) => t.musicStatus === 'added')
     : item.musicStatus === 'added'
@@ -488,45 +557,45 @@ export function Editor({
                           />
                         ) : (
                           release.tracklist.map((t) => (
-                          <button
-                            key={`${t.position}-${t.title}`}
-                            type="button"
-                            data-testid="discogs-track"
-                            aria-current={t === matchedTrack ? 'true' : undefined}
-                            onClick={() => selectTrack(t)}
-                            className={`flex w-full items-center gap-3 py-1.5 pr-3 pl-4 text-left hover:bg-[var(--color-panel-2)] ${
-                              t === matchedTrack ? 'bg-[var(--color-accent-soft)]' : ''
-                            }`}
-                          >
-                            <span className="w-8 shrink-0 text-xs tabular-nums text-fg-dim">
-                              {t.position}
-                            </span>
-                            <span className="min-w-0 flex-1 truncate text-sm">{t.title}</span>
-                            {t === matchedTrack && matchTier && (
-                              <svg
-                                data-testid="track-confidence"
-                                data-confidence={matchTier}
-                                aria-label={tr('editor.matchSuggested')}
-                                role="img"
-                                viewBox="0 0 24 24"
-                                fill="none"
-                                stroke="currentColor"
-                                strokeWidth={3}
-                                strokeLinecap="round"
-                                strokeLinejoin="round"
-                                className={`size-4 shrink-0 ${
-                                  matchTier === 'high' ? 'text-good' : 'text-warn'
-                                }`}
-                              >
-                                <title>{tr('editor.matchSuggested')}</title>
-                                <path d="M5 13l4 4L19 7" />
-                              </svg>
-                            )}
-                            {t.duration && (
-                              <span className="shrink-0 text-xs tabular-nums text-fg-dim">
-                                {t.duration}
+                            <button
+                              key={`${t.position}-${t.title}`}
+                              type="button"
+                              data-testid="discogs-track"
+                              aria-current={t === matchedTrack ? 'true' : undefined}
+                              onClick={() => selectTrack(t)}
+                              className={`flex w-full items-center gap-3 py-1.5 pr-3 pl-4 text-left hover:bg-[var(--color-panel-2)] ${
+                                t === matchedTrack ? 'bg-[var(--color-accent-soft)]' : ''
+                              }`}
+                            >
+                              <span className="w-8 shrink-0 text-xs tabular-nums text-fg-dim">
+                                {t.position}
                               </span>
-                            )}
+                              <span className="min-w-0 flex-1 truncate text-sm">{t.title}</span>
+                              {t === matchedTrack && matchTier && (
+                                <svg
+                                  data-testid="track-confidence"
+                                  data-confidence={matchTier}
+                                  aria-label={tr('editor.matchSuggested')}
+                                  role="img"
+                                  viewBox="0 0 24 24"
+                                  fill="none"
+                                  stroke="currentColor"
+                                  strokeWidth={3}
+                                  strokeLinecap="round"
+                                  strokeLinejoin="round"
+                                  className={`size-4 shrink-0 ${
+                                    matchTier === 'high' ? 'text-good' : 'text-warn'
+                                  }`}
+                                >
+                                  <title>{tr('editor.matchSuggested')}</title>
+                                  <path d="M5 13l4 4L19 7" />
+                                </svg>
+                              )}
+                              {t.duration && (
+                                <span className="shrink-0 text-xs tabular-nums text-fg-dim">
+                                  {t.duration}
+                                </span>
+                              )}
                             </button>
                           ))
                         )
@@ -675,10 +744,16 @@ export function Editor({
                             name={key}
                             label={tr(`fields.${key}`)}
                             value={shared ?? ''}
-                            placeholder={shared === undefined ? tr('editor.multipleValues') : undefined}
+                            placeholder={
+                              shared === undefined ? tr('editor.multipleValues') : undefined
+                            }
                             onChange={(v) => onChangeAllMeta?.({ [key]: v })}
                             suggestions={
-                              key === 'genre' ? genreChips : key === 'grouping' ? groupingPresets : undefined
+                              key === 'genre'
+                                ? genreChips
+                                : key === 'grouping'
+                                  ? groupingPresets
+                                  : undefined
                             }
                             multiSuggestions={key === 'grouping'}
                           />
@@ -712,7 +787,7 @@ export function Editor({
             </div>
           )}
 
-          {!isMulti && showSpectrum && (
+          {!isMulti && (showSpectrum || showLoudness) && (
             <div className="mt-6 border-t border-[var(--color-line)] pt-5">
               <SectionHeader
                 title={tr('editor.qualityTitle')}
@@ -740,86 +815,269 @@ export function Editor({
               />
               {spectrumOpen && (
                 <div className="mt-3">
-                  {analyzing ? (
-                    <div className="flex h-28 items-center justify-center gap-3 text-xs text-fg-dim">
-                      <WaveSpinner />
-                      {tr('editor.analyzing')}
-                    </div>
-                  ) : analyzeError ? (
-                    <p className="text-xs text-danger">{analyzeError}</p>
-                  ) : item.spectrum ? (
-                    <>
-                      <Spectrogram spectrum={item.spectrum} />
-                      {item.spectrum.cutoffHz !== null && (
-                        <p className="mt-2 text-xs text-fg-dim">
-                          {tr('editor.qualityCaption', {
-                            cutoff: formatKHz(item.spectrum.cutoffHz),
-                            nyquist: formatKHz(item.spectrum.sampleRateHz / 2),
-                          })}
-                        </p>
-                      )}
-                    </>
-                  ) : null}
+                  {showSpectrum &&
+                    (analyzing ? (
+                      <div className="flex h-28 items-center justify-center gap-3 text-xs text-fg-dim">
+                        <WaveSpinner />
+                        {tr('editor.analyzing')}
+                      </div>
+                    ) : analyzeError ? (
+                      <p className="text-xs text-danger">{analyzeError}</p>
+                    ) : item.spectrum ? (
+                      <>
+                        <Spectrogram spectrum={item.spectrum} />
+                        {item.spectrum.cutoffHz !== null && (
+                          <p className="mt-2 text-xs text-fg-dim">
+                            {tr('editor.qualityCaption', {
+                              cutoff: formatKHz(item.spectrum.cutoffHz),
+                              nyquist: formatKHz(item.spectrum.sampleRateHz / 2),
+                            })}
+                          </p>
+                        )}
+                      </>
+                    ) : null)}
+                  {showLoudness &&
+                    item.loudness &&
+                    (() => {
+                      const loud = item.loudness
+                      // The astats-derived checks each appear only when measured
+                      // (null = mono, a dead channel, or an unparseable reading).
+                      const cell = (
+                        id: string,
+                        label: string,
+                        value: string,
+                        grade: Grade,
+                        hint: string,
+                      ) => ({ id, label, value, grade, hint })
+                      const groups = [
+                        {
+                          id: 'loudness',
+                          label: tr('editor.loudnessGroupLoudness'),
+                          cells: [
+                            cell(
+                              'lufs',
+                              tr('editor.loudnessLufsLabel'),
+                              `${formatDb(loud.integratedLufs)} LUFS`,
+                              gradeLufs(loud.integratedLufs),
+                              tr('editor.loudnessLufsHint'),
+                            ),
+                            cell(
+                              'peak',
+                              tr('editor.loudnessPeakLabel'),
+                              `${formatDb(loud.truePeakDb)} dBTP`,
+                              gradeTruePeak(loud.truePeakDb),
+                              tr('editor.loudnessPeakHint'),
+                            ),
+                            cell(
+                              'range',
+                              tr('editor.loudnessRangeLabel'),
+                              `${formatDb(loud.lra)} LU`,
+                              gradeLra(loud.lra),
+                              tr('editor.loudnessRangeHint'),
+                            ),
+                            loud.crestDb !== null &&
+                              cell(
+                                'crest',
+                                tr('editor.loudnessCrestLabel'),
+                                `${formatDb(loud.crestDb)} dB`,
+                                gradeCrest(loud.crestDb),
+                                tr('editor.loudnessCrestHint'),
+                              ),
+                          ].filter((c) => c !== false),
+                        },
+                        {
+                          id: 'signal',
+                          label: tr('editor.loudnessGroupSignal'),
+                          cells: [
+                            loud.channelBalanceDb !== null &&
+                              cell(
+                                'balance',
+                                tr('editor.loudnessBalanceLabel'),
+                                `${formatDb(loud.channelBalanceDb)} dB`,
+                                gradeBalance(loud.channelBalanceDb),
+                                tr('editor.loudnessBalanceHint'),
+                              ),
+                            loud.dcOffset !== null &&
+                              cell(
+                                'dc',
+                                tr('editor.loudnessDcLabel'),
+                                formatPercent(loud.dcOffset),
+                                gradeDcOffset(loud.dcOffset),
+                                tr('editor.loudnessDcHint'),
+                              ),
+                            loud.noiseFloorDb !== null &&
+                              cell(
+                                'noise',
+                                tr('editor.loudnessNoiseLabel'),
+                                `${formatDb(loud.noiseFloorDb)} dB`,
+                                gradeNoiseFloor(loud.noiseFloorDb),
+                                tr('editor.loudnessNoiseHint'),
+                              ),
+                          ].filter((c) => c !== false),
+                        },
+                      ].filter((g) => g.cells.length > 0)
+                      return (
+                        <div data-testid="loudness-readout" className="mt-3 space-y-3">
+                          {groups.map((group, gi) => (
+                            <div key={group.id}>
+                              <div className="mb-1.5 flex items-center justify-between">
+                                <span className="text-[10px] font-medium uppercase tracking-wider text-fg-dim">
+                                  {group.label}
+                                </span>
+                                {gi === 0 && (
+                                  <button
+                                    type="button"
+                                    data-testid="loudness-help-toggle"
+                                    onClick={() => setLoudnessHelpOpen(true)}
+                                    title={tr('editor.loudnessHelpTitle')}
+                                    className="press flex h-5 w-5 items-center justify-center rounded-full text-fg-dim hover:bg-[var(--color-panel-2)] hover:text-fg"
+                                  >
+                                    <svg
+                                      viewBox="0 0 24 24"
+                                      fill="none"
+                                      stroke="currentColor"
+                                      strokeWidth={2}
+                                      strokeLinecap="round"
+                                      strokeLinejoin="round"
+                                      className="h-3.5 w-3.5"
+                                      aria-hidden="true"
+                                    >
+                                      <circle cx="12" cy="12" r="10" />
+                                      <line x1="12" y1="16" x2="12" y2="12" />
+                                      <line x1="12" y1="8" x2="12.01" y2="8" />
+                                    </svg>
+                                  </button>
+                                )}
+                              </div>
+                              <div className="grid gap-2 [grid-template-columns:repeat(auto-fill,minmax(6.5rem,1fr))]">
+                                {group.cells.map((c) => (
+                                  <div
+                                    key={c.id}
+                                    data-testid={`loudness-pill-${c.id}`}
+                                    data-grade={c.grade}
+                                    title={c.hint}
+                                    className="rounded-lg bg-[var(--color-field)] px-3 py-2"
+                                  >
+                                    <div className="flex items-center gap-1.5">
+                                      <span
+                                        className={`h-1.5 w-1.5 shrink-0 rounded-full ${GRADE_DOT[c.grade]}`}
+                                      />
+                                      <span className="truncate text-[10px] uppercase tracking-wide text-fg-dim">
+                                        {c.label}
+                                      </span>
+                                    </div>
+                                    <div
+                                      className={`mt-0.5 text-sm font-medium tabular-nums ${GRADE_TEXT[c.grade]}`}
+                                    >
+                                      {c.value}
+                                    </div>
+                                  </div>
+                                ))}
+                              </div>
+                            </div>
+                          ))}
+                        </div>
+                      )
+                    })()}
                 </div>
               )}
             </div>
           )}
 
+          {loudnessHelpOpen && <LoudnessHelpModal onClose={() => setLoudnessHelpOpen(false)} />}
+
           {!isMulti && (
-          <div className="mt-6 border-t border-[var(--color-line)] pt-5">
-            <SectionHeader
-              title={tr('editor.outputName')}
-              open={outputOpen}
-              onToggle={() => setOutputOpen((v) => !v)}
-              right={
-                <button
-                  type="button"
-                  data-testid="regenerate-output-name"
-                  onClick={() =>
-                    onChange({ outputName: renderOutputName(filenameFormat, item.meta) || item.fileName })
-                  }
-                  title={tr('editor.regenerateHint')}
-                  className="press flex items-center gap-1.5 rounded-md text-xs text-fg-dim hover:text-fg"
-                >
-                  <svg
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    aria-hidden="true"
-                    className="h-3 w-3"
+            <div className="mt-6 border-t border-[var(--color-line)] pt-5">
+              <SectionHeader
+                title={tr('editor.outputName')}
+                open={outputOpen}
+                onToggle={() => setOutputOpen((v) => !v)}
+                right={
+                  <button
+                    type="button"
+                    data-testid="regenerate-output-name"
+                    onClick={() =>
+                      onChange({
+                        outputName: renderOutputName(filenameFormat, item.meta) || item.fileName,
+                      })
+                    }
+                    title={tr('editor.regenerateHint')}
+                    className="press flex items-center gap-1.5 rounded-md text-xs text-fg-dim hover:text-fg"
                   >
-                    <path d="M3 12a9 9 0 0 1 15-6.7L21 8" />
-                    <path d="M21 3v5h-5" />
-                    <path d="M21 12a9 9 0 0 1-15 6.7L3 16" />
-                    <path d="M3 21v-5h5" />
-                  </svg>
-                  {tr('editor.regenerate')}
-                </button>
+                    <svg
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      aria-hidden="true"
+                      className="h-3 w-3"
+                    >
+                      <path d="M3 12a9 9 0 0 1 15-6.7L21 8" />
+                      <path d="M21 3v5h-5" />
+                      <path d="M21 12a9 9 0 0 1-15 6.7L3 16" />
+                      <path d="M3 21v-5h5" />
+                    </svg>
+                    {tr('editor.regenerate')}
+                  </button>
+                }
+              />
+              {outputOpen && (
+                <label className="relative mt-3 block">
+                  <input
+                    data-testid="output-name"
+                    value={item.outputName ?? defaultOutputName}
+                    onChange={(e) => onChange({ outputName: e.target.value })}
+                    className="w-full rounded-lg border border-[var(--color-line)] bg-[var(--color-field)] py-2 pr-14 pl-3 text-sm outline-none focus:border-[var(--color-accent)]"
+                  />
+                  <span className="pointer-events-none absolute top-1/2 right-3 -translate-y-1/2 text-sm text-fg-dim">
+                    .{format}
+                  </span>
+                </label>
+              )}
+              {outputOpen && (
+                <p className="mt-2 text-xs text-fg-dim" data-testid="output-name-hint">
+                  {willEditInPlace
+                    ? tr('editor.outputNameHintInPlace')
+                    : tr('editor.outputNameHint')}
+                </p>
+              )}
+            </div>
+          )}
+
+          <div
+            data-testid="editor-normalize"
+            className="mt-6 border-t border-[var(--color-line)] pt-5"
+          >
+            <SectionHeader
+              title={tr('normalize.title')}
+              open={normalizeOpen}
+              onToggle={() => setNormalizeOpen((v) => !v)}
+              right={
+                normalizeCfg.mode !== 'none' ? (
+                  <span
+                    data-testid="normalize-active-badge"
+                    className="rounded-full bg-[var(--color-accent)]/15 px-2.5 py-1 text-xs font-medium text-[var(--color-accent)]"
+                  >
+                    {tr(`normalize.mode.${normalizeCfg.mode}`)}
+                  </span>
+                ) : undefined
               }
             />
-            {outputOpen && (
-              <label className="relative mt-3 block">
-                <input
-                  data-testid="output-name"
-                  value={item.outputName ?? defaultOutputName}
-                  onChange={(e) => onChange({ outputName: e.target.value })}
-                  className="w-full rounded-lg border border-[var(--color-line)] bg-[var(--color-field)] py-2 pr-14 pl-3 text-sm outline-none focus:border-[var(--color-accent)]"
+            {normalizeOpen && (
+              <div className="mt-3">
+                <p className="mb-3 text-xs text-fg-dim">{tr('normalize.hint')}</p>
+                <NormalizeControls
+                  value={normalizeCfg}
+                  onChange={(n) => {
+                    setNormalizeCfg(n)
+                    onNormalizeChange?.(n)
+                  }}
                 />
-                <span className="pointer-events-none absolute top-1/2 right-3 -translate-y-1/2 text-sm text-fg-dim">
-                  .{format}
-                </span>
-              </label>
-            )}
-            {outputOpen && (
-              <p className="mt-2 text-xs text-fg-dim" data-testid="output-name-hint">
-                {willEditInPlace ? tr('editor.outputNameHintInPlace') : tr('editor.outputNameHint')}
-              </p>
+              </div>
             )}
           </div>
-          )}
         </div>
 
         <div className="border-t border-[var(--color-line)] bg-[var(--color-ink)] px-6 py-3.5">

--- a/apps/desktop/src/renderer/src/components/Editor.tsx
+++ b/apps/desktop/src/renderer/src/components/Editor.tsx
@@ -1095,6 +1095,39 @@ export function Editor({
             </div>
           )}
           <div className="space-y-2">
+            {normalizeCfg.mode !== 'none' && (
+              <button
+                type="button"
+                data-testid="convert-normalize-note"
+                onClick={() => setNormalizeOpen(true)}
+                title={tr('normalize.title')}
+                className="press flex w-full items-center justify-center gap-1.5 text-xs text-[var(--color-accent)] hover:underline"
+              >
+                <svg
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                  strokeLinecap="round"
+                  aria-hidden="true"
+                  className="h-3.5 w-3.5"
+                >
+                  <line x1="4" y1="21" x2="4" y2="14" />
+                  <line x1="4" y1="10" x2="4" y2="3" />
+                  <line x1="12" y1="21" x2="12" y2="12" />
+                  <line x1="12" y1="8" x2="12" y2="3" />
+                  <line x1="20" y1="21" x2="20" y2="16" />
+                  <line x1="20" y1="12" x2="20" y2="3" />
+                  <line x1="1" y1="14" x2="7" y2="14" />
+                  <line x1="9" y1="8" x2="15" y2="8" />
+                  <line x1="17" y1="16" x2="23" y2="16" />
+                </svg>
+                {tr(`normalize.mode.${normalizeCfg.mode}`)} ·{' '}
+                {normalizeCfg.mode === 'loudness'
+                  ? `${normalizeCfg.targetLufs} LUFS`
+                  : `${normalizeCfg.peakDb} dBFS`}
+              </button>
+            )}
             <ExportButton
               status={isMulti ? 'idle' : item.status}
               stale={!isMulti && stale}

--- a/apps/desktop/src/renderer/src/components/FindReplaceModal.test.tsx
+++ b/apps/desktop/src/renderer/src/components/FindReplaceModal.test.tsx
@@ -28,7 +28,14 @@ const emptyMeta: TrackMetadata = {
 }
 
 function track(id: string, meta: Partial<TrackMetadata>): TrackItem {
-  return { id, inputPath: `/m/${id}`, fileName: `${id}.flac`, query: '', status: 'idle', meta: { ...emptyMeta, ...meta } }
+  return {
+    id,
+    inputPath: `/m/${id}`,
+    fileName: `${id}.flac`,
+    query: '',
+    status: 'idle',
+    meta: { ...emptyMeta, ...meta },
+  }
 }
 
 function renderModal(tracks: TrackItem[]) {

--- a/apps/desktop/src/renderer/src/components/FindReplaceModal.tsx
+++ b/apps/desktop/src/renderer/src/components/FindReplaceModal.tsx
@@ -1,5 +1,5 @@
 import type React from 'react'
-import { useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { TrackMetadata } from '../../../shared/types'
 import { findReplaceTrack, isValidRegex } from '../lib/findReplace'
@@ -23,7 +23,12 @@ export function FindReplaceModal({ tracks, onApply, onClose }: Props): React.JSX
   const [replace, setReplace] = useState('')
   const [regex, setRegex] = useState(false)
   const dialogRef = useRef<HTMLDivElement>(null)
+  const findInputRef = useRef<HTMLInputElement>(null)
   useFocusTrap(dialogRef)
+
+  useEffect(() => {
+    findInputRef.current?.focus()
+  }, [])
 
   const badRegex = regex && find.length > 0 && !isValidRegex(find)
   const patches =
@@ -84,11 +89,11 @@ export function FindReplaceModal({ tracks, onApply, onClose }: Props): React.JSX
               {tr('findReplace.find')}
             </span>
             <input
+              ref={findInputRef}
               data-testid="find-replace-find"
               value={find}
               onChange={(e) => setFind(e.target.value)}
               aria-invalid={badRegex}
-              autoFocus
               spellCheck={false}
               className={`w-full rounded-lg border bg-[var(--color-field)] px-3 py-2 text-sm outline-none ${
                 badRegex

--- a/apps/desktop/src/renderer/src/components/LoudnessHelpModal.tsx
+++ b/apps/desktop/src/renderer/src/components/LoudnessHelpModal.tsx
@@ -1,0 +1,95 @@
+import type React from 'react'
+import { useEffect, useRef } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useFocusTrap } from './useFocusTrap'
+
+interface Props {
+  onClose: () => void
+}
+
+const METRICS = ['Lufs', 'Peak', 'Range', 'Crest', 'Balance', 'Dc', 'Noise'] as const
+
+// Plain-language explanation of the loudness pills, opened from the ⓘ button.
+// A modal (not an inline panel) keeps the editor uncluttered: the figures need
+// explaining once, not on every edit.
+export function LoudnessHelpModal({ onClose }: Props): React.JSX.Element {
+  const { t: tr } = useTranslation()
+  const dialogRef = useRef<HTMLDivElement>(null)
+  useFocusTrap(dialogRef)
+
+  // App's global Escape handler only closes app-level overlays; this modal is
+  // Editor-local, so it dismisses itself on Escape like any other dialog.
+  useEffect(() => {
+    function onKey(e: KeyboardEvent): void {
+      if (e.key === 'Escape') onClose()
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [onClose])
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <button
+        type="button"
+        data-testid="loudness-help-backdrop"
+        aria-label={tr('common.close')}
+        onClick={onClose}
+        className="animate-overlay absolute inset-0 bg-black/60 backdrop-blur-sm"
+      />
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        data-testid="loudness-help"
+        className="animate-pop relative z-10 flex max-h-[80vh] w-[520px] flex-col rounded-2xl border border-[var(--color-line-strong)] bg-[var(--color-panel)] p-6"
+      >
+        <div className="-mx-6 -mt-6 mb-4 flex items-center justify-between border-b border-[var(--color-line)] px-6 pt-5 pb-3">
+          <h2 className="text-base font-semibold">{tr('editor.loudnessHelpTitle')}</h2>
+          <button
+            type="button"
+            data-testid="loudness-help-close"
+            onClick={onClose}
+            aria-label={tr('common.close')}
+            className="press flex h-7 w-7 items-center justify-center rounded-lg text-fg-muted hover:bg-[var(--color-panel-2)] hover:text-fg"
+          >
+            <svg
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden="true"
+              className="h-4 w-4"
+            >
+              <path d="M18 6 6 18M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        <div className="-mx-2 space-y-3 overflow-y-auto px-2 text-sm leading-relaxed text-fg-dim">
+          {METRICS.map((m) => (
+            <p key={m}>
+              <span className="font-medium text-fg">{tr(`editor.loudness${m}Label`)}</span>{' '}
+              {tr(`editor.loudness${m}Help`)}
+            </p>
+          ))}
+          <p className="flex flex-wrap items-center gap-x-4 gap-y-1.5 border-t border-[var(--color-line)] pt-3">
+            <span className="inline-flex items-center gap-1.5">
+              <span className="h-2 w-2 rounded-full bg-good" />
+              {tr('editor.loudnessGradeGood')}
+            </span>
+            <span className="inline-flex items-center gap-1.5">
+              <span className="h-2 w-2 rounded-full bg-warn" />
+              {tr('editor.loudnessGradeWarn')}
+            </span>
+            <span className="inline-flex items-center gap-1.5">
+              <span className="h-2 w-2 rounded-full bg-danger" />
+              {tr('editor.loudnessGradeBad')}
+            </span>
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/desktop/src/renderer/src/components/NormalizeControls.tsx
+++ b/apps/desktop/src/renderer/src/components/NormalizeControls.tsx
@@ -1,0 +1,192 @@
+import type React from 'react'
+import { useRef } from 'react'
+import { useTranslation } from 'react-i18next'
+import type { NormalizeConfig, NormalizeMode } from '../../../shared/types'
+
+interface Props {
+  value: NormalizeConfig
+  onChange: (next: NormalizeConfig) => void
+}
+
+const MODES: NormalizeMode[] = ['none', 'loudness', 'peak']
+
+// Loudness presets cover the common delivery targets; peak presets are just a
+// safe ceiling. Picking one fills the numbers, which stay editable for anything
+// in between — that is the "maximum flexibility" the user asked for.
+const LOUDNESS_PRESETS = [
+  { id: 'streaming', lufs: -14, tp: -1 },
+  { id: 'club', lufs: -9, tp: -1 },
+  { id: 'broadcast', lufs: -23, tp: -1 },
+]
+const PEAK_PRESETS = [
+  { id: 'safe', peak: -1 },
+  { id: 'hot', peak: -0.1 },
+]
+
+function NumberField({
+  testid,
+  label,
+  value,
+  onChange,
+  inputRef,
+}: {
+  testid: string
+  label: string
+  value: number
+  onChange: (n: number) => void
+  inputRef?: React.RefObject<HTMLInputElement | null>
+}): React.JSX.Element {
+  return (
+    <label className="flex flex-col gap-1 text-xs text-fg-muted">
+      {label}
+      <input
+        ref={inputRef}
+        type="number"
+        data-testid={testid}
+        value={value}
+        step={0.1}
+        onChange={(e) => {
+          const n = Number.parseFloat(e.target.value)
+          if (Number.isFinite(n)) onChange(n)
+        }}
+        className="w-24 rounded-lg border border-[var(--color-line)] bg-[var(--color-field)] px-2.5 py-1.5 text-sm tabular-nums outline-none focus:border-[var(--color-accent)]"
+      />
+    </label>
+  )
+}
+
+// The normalization picker, shared by Settings (global default) and the Editor
+// (per-track override). Pure controlled component: it never reaches for ffmpeg or
+// settings, it just edits a NormalizeConfig.
+export function NormalizeControls({ value, onChange }: Props): React.JSX.Element {
+  const { t: tr } = useTranslation()
+  // Focus targets for the Custom chip, so picking "Custom" drops the caret straight
+  // into the field the user is about to tune.
+  const lufsRef = useRef<HTMLInputElement>(null)
+  const peakRef = useRef<HTMLInputElement>(null)
+  const loudnessIsCustom = !LOUDNESS_PRESETS.some(
+    (p) => p.lufs === value.targetLufs && p.tp === value.truePeakDb,
+  )
+  const peakIsCustom = !PEAK_PRESETS.some((p) => p.peak === value.peakDb)
+  const customChipClass = (active: boolean): string =>
+    `rounded-full border px-3 py-1 text-xs transition-colors ${
+      active
+        ? 'border-[var(--color-accent)] text-[var(--color-accent)]'
+        : 'border-[var(--color-line-strong)] text-fg-muted hover:text-fg'
+    }`
+  return (
+    <div>
+      <div className="inline-flex gap-1 rounded-lg bg-[var(--color-field)] p-1">
+        {MODES.map((mode) => (
+          <button
+            key={mode}
+            type="button"
+            data-testid={`normalize-mode-${mode}`}
+            aria-pressed={value.mode === mode}
+            onClick={() => onChange({ ...value, mode })}
+            className={`rounded-md px-3 py-1.5 text-sm transition-colors ${
+              value.mode === mode
+                ? 'bg-[var(--color-panel-2)] text-fg'
+                : 'text-fg-muted hover:text-fg'
+            }`}
+          >
+            {tr(`normalize.mode.${mode}`)}
+          </button>
+        ))}
+      </div>
+
+      {value.mode === 'loudness' && (
+        <div className="mt-3 space-y-3">
+          <div className="flex flex-wrap gap-1.5">
+            {LOUDNESS_PRESETS.map((p) => {
+              const active = value.targetLufs === p.lufs && value.truePeakDb === p.tp
+              return (
+                <button
+                  key={p.id}
+                  type="button"
+                  data-testid={`normalize-preset-${p.id}`}
+                  aria-pressed={active}
+                  onClick={() => onChange({ ...value, targetLufs: p.lufs, truePeakDb: p.tp })}
+                  className={`rounded-full border px-3 py-1 text-xs transition-colors ${
+                    active
+                      ? 'border-[var(--color-accent)] text-[var(--color-accent)]'
+                      : 'border-[var(--color-line-strong)] text-fg-muted hover:text-fg'
+                  }`}
+                >
+                  {tr(`normalize.preset.${p.id}`)}
+                </button>
+              )
+            })}
+            <button
+              type="button"
+              data-testid="normalize-preset-custom"
+              aria-pressed={loudnessIsCustom}
+              onClick={() => lufsRef.current?.select()}
+              className={customChipClass(loudnessIsCustom)}
+            >
+              {tr('normalize.preset.custom')}
+            </button>
+          </div>
+          <div className="flex gap-4">
+            <NumberField
+              testid="normalize-target-lufs"
+              label={tr('normalize.targetLufs')}
+              value={value.targetLufs}
+              onChange={(n) => onChange({ ...value, targetLufs: n })}
+              inputRef={lufsRef}
+            />
+            <NumberField
+              testid="normalize-true-peak"
+              label={tr('normalize.truePeak')}
+              value={value.truePeakDb}
+              onChange={(n) => onChange({ ...value, truePeakDb: n })}
+            />
+          </div>
+        </div>
+      )}
+
+      {value.mode === 'peak' && (
+        <div className="mt-3 space-y-3">
+          <div className="flex flex-wrap gap-1.5">
+            {PEAK_PRESETS.map((p) => (
+              <button
+                key={p.id}
+                type="button"
+                data-testid={`normalize-preset-${p.id}`}
+                aria-pressed={value.peakDb === p.peak}
+                onClick={() => onChange({ ...value, peakDb: p.peak })}
+                className={`rounded-full border px-3 py-1 text-xs transition-colors ${
+                  value.peakDb === p.peak
+                    ? 'border-[var(--color-accent)] text-[var(--color-accent)]'
+                    : 'border-[var(--color-line-strong)] text-fg-muted hover:text-fg'
+                }`}
+              >
+                {tr(`normalize.preset.${p.id}`)}
+              </button>
+            ))}
+            <button
+              type="button"
+              data-testid="normalize-preset-custom"
+              aria-pressed={peakIsCustom}
+              onClick={() => peakRef.current?.select()}
+              className={customChipClass(peakIsCustom)}
+            >
+              {tr('normalize.preset.custom')}
+            </button>
+          </div>
+          <NumberField
+            testid="normalize-peak"
+            label={tr('normalize.peakDb')}
+            value={value.peakDb}
+            onChange={(n) => onChange({ ...value, peakDb: n })}
+            inputRef={peakRef}
+          />
+        </div>
+      )}
+
+      {value.mode !== 'none' && (
+        <p className="mt-3 text-xs text-warn">{tr('normalize.cueWarning')}</p>
+      )}
+    </div>
+  )
+}

--- a/apps/desktop/src/renderer/src/components/SettingsModal.test.tsx
+++ b/apps/desktop/src/renderer/src/components/SettingsModal.test.tsx
@@ -30,6 +30,8 @@ const settings: Settings = {
   coverMaxSize: 1200,
   coverSquare: false,
   showSpectrum: true,
+  showLoudness: true,
+  normalize: { mode: 'none', targetLufs: -14, truePeakDb: -1, peakDb: -1 },
   hasSeenOnboarding: true,
   conversionCount: 0,
 }

--- a/apps/desktop/src/renderer/src/components/SettingsModal.tsx
+++ b/apps/desktop/src/renderer/src/components/SettingsModal.tsx
@@ -6,6 +6,7 @@ import { FIELD_DEFS, moveItem } from '../lib/fields'
 import { insertToken } from '../lib/insertToken'
 import { renderOutputName } from '../lib/outputName'
 import { MANUAL_SECONDS_PER_CONVERSION, formatTimeSaved, timeSavedSeconds } from '../lib/stats'
+import { NormalizeControls } from './NormalizeControls'
 import { useFocusTrap } from './useFocusTrap'
 
 const THEMES: ThemePref[] = ['system', 'light', 'dark']
@@ -47,14 +48,22 @@ interface Props {
   initialTab?: Tab
 }
 
-type Tab = 'general' | 'naming' | 'artwork' | 'fields' | 'stats'
+type Tab = 'general' | 'conversion' | 'naming' | 'artwork' | 'fields' | 'stats'
 
 // Ordered to mirror Meta's preferences flow: broad app settings, then what the
 // editor shows, then artwork, then editing behavior. Stats trails last as the one
 // read-only, informational tab.
-const TABS: Tab[] = ['general', 'fields', 'artwork', 'naming', 'stats']
+// Ordered by workflow: app setup, then output, then per-track editing prefs, then results.
+const TABS: Tab[] = ['general', 'conversion', 'naming', 'fields', 'artwork', 'stats']
 
 const TAB_ICONS: Record<Tab, React.JSX.Element> = {
+  conversion: (
+    <>
+      <path d="M12 3v11" />
+      <path d="m7 10 5 5 5-5" />
+      <line x1="4" y1="20" x2="20" y2="20" />
+    </>
+  ),
   general: (
     <>
       <line x1="4" y1="8" x2="20" y2="8" />
@@ -119,6 +128,8 @@ export function SettingsModal({
   const [coverMaxSize, setCoverMaxSize] = useState(String(settings.coverMaxSize))
   const [coverSquare, setCoverSquare] = useState(settings.coverSquare)
   const [showSpectrum, setShowSpectrum] = useState(settings.showSpectrum)
+  const [showLoudness, setShowLoudness] = useState(settings.showLoudness)
+  const [normalize, setNormalize] = useState(settings.normalize)
   const formatRef = useRef<HTMLInputElement>(null)
   const dialogRef = useRef<HTMLDivElement>(null)
   useFocusTrap(dialogRef)
@@ -163,6 +174,8 @@ export function SettingsModal({
       coverMaxSize: Number.isFinite(max) && max >= 0 ? max : 1200,
       coverSquare,
       showSpectrum,
+      showLoudness,
+      normalize,
     })
     onClose()
   }
@@ -268,8 +281,12 @@ export function SettingsModal({
                   discogs.com/settings/developers
                 </a>
               </p>
+            </>
+          )}
 
-              <p className="mb-3 border-t border-[var(--color-line)] pt-5 text-xs font-medium uppercase tracking-wide text-fg-dim">
+          {tab === 'conversion' && (
+            <>
+              <p className="mb-3 text-xs font-medium uppercase tracking-wide text-fg-dim">
                 {tr('settings.outputSection')}
               </p>
 
@@ -343,6 +360,12 @@ export function SettingsModal({
                   )}
                 </>
               )}
+
+              <p className="mt-5 mb-1.5 border-t border-[var(--color-line)] pt-5 text-sm font-medium text-fg-muted">
+                {tr('normalize.title')}
+              </p>
+              <p className="mb-3 text-xs text-fg-dim">{tr('normalize.hint')}</p>
+              <NormalizeControls value={normalize} onChange={setNormalize} />
             </>
           )}
 
@@ -434,6 +457,19 @@ export function SettingsModal({
                     <span className="text-sm">{tr('settings.showSpectrum')}</span>
                   </label>
                   <p className="mt-1.5 text-xs text-fg-dim">{tr('settings.showSpectrumHint')}</p>
+                </div>
+                <div>
+                  <label className="flex cursor-pointer items-center gap-3">
+                    <input
+                      data-testid="settings-show-loudness"
+                      type="checkbox"
+                      checked={showLoudness}
+                      onChange={(e) => setShowLoudness(e.target.checked)}
+                      className="h-4 w-4 accent-[var(--color-accent)]"
+                    />
+                    <span className="text-sm">{tr('settings.showLoudness')}</span>
+                  </label>
+                  <p className="mt-1.5 text-xs text-fg-dim">{tr('settings.showLoudnessHint')}</p>
                 </div>
               </div>
             </>

--- a/apps/desktop/src/renderer/src/components/TrackContextMenu.tsx
+++ b/apps/desktop/src/renderer/src/components/TrackContextMenu.tsx
@@ -1,0 +1,139 @@
+import type React from 'react'
+import { useEffect, useLayoutEffect, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import type { TrackItem } from '../types'
+
+interface Props {
+  track: TrackItem
+  x: number
+  y: number
+  onClose: () => void
+  onSearch: (id: string) => void
+  onRemove: (id: string) => void
+  onTrash: (track: TrackItem) => void
+}
+
+function MenuItem({
+  label,
+  testid,
+  danger,
+  onClick,
+}: {
+  label: string
+  testid: string
+  danger?: boolean
+  onClick: () => void
+}): React.JSX.Element {
+  return (
+    <button
+      type="button"
+      role="menuitem"
+      data-testid={testid}
+      onClick={onClick}
+      className={`block w-full rounded-md px-3 py-1.5 text-left text-sm transition-colors hover:bg-[var(--color-panel-2)] ${
+        danger ? 'text-danger' : 'text-fg'
+      }`}
+    >
+      {label}
+    </button>
+  )
+}
+
+// Right-click menu for a single track. Reveal/open/copy talk to the OS directly through
+// window.api; the list-level actions (search, remove, trash) are delegated to App so the
+// trash flow can route through its confirm dialog. Labels switch on platform because the
+// OS file manager and recycle location differ between macOS and Windows.
+export function TrackContextMenu({
+  track,
+  x,
+  y,
+  onClose,
+  onSearch,
+  onRemove,
+  onTrash,
+}: Props): React.JSX.Element {
+  const { t: tr } = useTranslation()
+  const menuRef = useRef<HTMLDivElement>(null)
+  const [pos, setPos] = useState({ x, y })
+  const isWin = window.api.platform === 'win32'
+
+  // Keep the menu fully on screen — flip it back inside the viewport once we know its size.
+  useLayoutEffect(() => {
+    const el = menuRef.current
+    if (!el) return
+    const { width, height } = el.getBoundingClientRect()
+    setPos({
+      x: Math.min(x, window.innerWidth - width - 8),
+      y: Math.min(y, window.innerHeight - height - 8),
+    })
+  }, [x, y])
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') onClose()
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [onClose])
+
+  function run(action: () => void): void {
+    action()
+    onClose()
+  }
+
+  return (
+    <div className="fixed inset-0 z-50">
+      <button
+        type="button"
+        data-testid="track-menu-backdrop"
+        aria-label={tr('common.close')}
+        onClick={onClose}
+        onContextMenu={(e) => {
+          e.preventDefault()
+          onClose()
+        }}
+        className="absolute inset-0"
+      />
+      <div
+        ref={menuRef}
+        role="menu"
+        data-testid="track-menu"
+        style={{ top: pos.y, left: pos.x }}
+        className="animate-pop absolute min-w-[210px] rounded-lg border border-[var(--color-line-strong)] bg-[var(--color-panel)] p-1 shadow-xl"
+      >
+        <MenuItem
+          testid="track-menu-reveal"
+          label={tr(isWin ? 'trackList.context.revealWin' : 'trackList.context.reveal')}
+          onClick={() => run(() => window.api.reveal(track.inputPath))}
+        />
+        <MenuItem
+          testid="track-menu-open"
+          label={tr('trackList.context.open')}
+          onClick={() => run(() => window.api.openFile(track.inputPath))}
+        />
+        <MenuItem
+          testid="track-menu-copy"
+          label={tr('trackList.context.copyPath')}
+          onClick={() => run(() => window.api.copyText(track.inputPath))}
+        />
+        <MenuItem
+          testid="track-menu-search"
+          label={tr('trackList.context.search')}
+          onClick={() => run(() => onSearch(track.id))}
+        />
+        <div className="my-1 h-px bg-[var(--color-line)]" />
+        <MenuItem
+          testid="track-menu-remove"
+          label={tr('trackList.context.remove')}
+          onClick={() => run(() => onRemove(track.id))}
+        />
+        <MenuItem
+          testid="track-menu-trash"
+          danger
+          label={tr(isWin ? 'trackList.context.trashWin' : 'trackList.context.trash')}
+          onClick={() => run(() => onTrash(track))}
+        />
+      </div>
+    </div>
+  )
+}

--- a/apps/desktop/src/renderer/src/components/TrackList.test.tsx
+++ b/apps/desktop/src/renderer/src/components/TrackList.test.tsx
@@ -150,9 +150,9 @@ describe('TrackList', () => {
   it('marks every selected row, including ones that are not the primary', () => {
     renderList([track({ id: 'a' }), track({ id: 'b' }), track({ id: 'c' })], 'a', ['a', 'b'])
     const rows = screen.getAllByTestId('track-row')
-    expect(rows[0]).toHaveAttribute('aria-selected', 'true')
-    expect(rows[1]).toHaveAttribute('aria-selected', 'true')
-    expect(rows[2]).toHaveAttribute('aria-selected', 'false')
+    expect(rows[0]).toHaveAttribute('aria-pressed', 'true')
+    expect(rows[1]).toHaveAttribute('aria-pressed', 'true')
+    expect(rows[2]).toHaveAttribute('aria-pressed', 'false')
   })
 
   it('removes a track without selecting it when the remove control is clicked', () => {

--- a/apps/desktop/src/renderer/src/components/TrackList.test.tsx
+++ b/apps/desktop/src/renderer/src/components/TrackList.test.tsx
@@ -1,12 +1,24 @@
 // @vitest-environment jsdom
 import '@testing-library/jest-dom/vitest'
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// TrackContextMenu reads window.api at render; install a stub before importing it.
+const api = { platform: 'darwin', reveal: vi.fn(), openFile: vi.fn(), copyText: vi.fn() }
+vi.hoisted(() => {
+  ;(globalThis.window as unknown as { api: unknown }).api = {}
+})
+
 import '../i18n'
 import type { TrackMetadata } from '../../../shared/types'
 import type { TrackItem } from '../types'
 import { TrackList } from './TrackList'
 
+beforeEach(() => {
+  Object.assign(window, { api })
+  api.platform = 'darwin'
+  vi.clearAllMocks()
+})
 afterEach(cleanup)
 
 // A full TrackItem so the list renders exactly as it does in the app; callers
@@ -49,6 +61,8 @@ function renderList(
   const onSelect = vi.fn()
   const onRemove = vi.fn()
   const onPrefetch = vi.fn()
+  const onSearch = vi.fn()
+  const onTrash = vi.fn()
   render(
     <TrackList
       tracks={tracks}
@@ -58,9 +72,11 @@ function renderList(
       onSelect={onSelect}
       onRemove={onRemove}
       onPrefetch={onPrefetch}
+      onSearch={onSearch}
+      onTrash={onTrash}
     />,
   )
-  return { onSelect, onRemove, onPrefetch }
+  return { onSelect, onRemove, onPrefetch, onSearch, onTrash }
 }
 
 describe('TrackList', () => {
@@ -159,5 +175,71 @@ describe('TrackList', () => {
     const { onPrefetch } = renderList([track({ id: 'a' })])
     fireEvent.focus(screen.getByTestId('track-row'))
     expect(onPrefetch).toHaveBeenCalledWith('a')
+  })
+})
+
+describe('TrackList context menu', () => {
+  it('opens on right click', () => {
+    renderList([track({ id: 'a' })])
+    expect(screen.queryByTestId('track-menu')).toBeNull()
+    fireEvent.contextMenu(screen.getByTestId('track-row'))
+    expect(screen.getByTestId('track-menu')).toBeInTheDocument()
+  })
+
+  // Right-clicking an unselected row makes it the active track so the single-track
+  // menu acts on what the user clicked, not the previous selection.
+  it('selects an unselected row before opening', () => {
+    const { onSelect } = renderList([track({ id: 'a' }), track({ id: 'b' })], 'a', ['a'])
+    fireEvent.contextMenu(screen.getAllByTestId('track-row')[1])
+    expect(onSelect).toHaveBeenCalledWith('b', {})
+  })
+
+  it('reveals, opens and copies the path of the original file', () => {
+    renderList([track({ id: 'a' })])
+    const row = () => screen.getByTestId('track-row')
+    fireEvent.contextMenu(row())
+    fireEvent.click(screen.getByTestId('track-menu-reveal'))
+    fireEvent.contextMenu(row())
+    fireEvent.click(screen.getByTestId('track-menu-open'))
+    fireEvent.contextMenu(row())
+    fireEvent.click(screen.getByTestId('track-menu-copy'))
+    expect(api.reveal).toHaveBeenCalledWith('/music/a.wav')
+    expect(api.openFile).toHaveBeenCalledWith('/music/a.wav')
+    expect(api.copyText).toHaveBeenCalledWith('/music/a.wav')
+  })
+
+  it('delegates search and trash to the list owner', () => {
+    const t = track({ id: 'a' })
+    const { onSearch, onTrash } = renderList([t])
+    fireEvent.contextMenu(screen.getByTestId('track-row'))
+    fireEvent.click(screen.getByTestId('track-menu-search'))
+    fireEvent.contextMenu(screen.getByTestId('track-row'))
+    fireEvent.click(screen.getByTestId('track-menu-trash'))
+    expect(onSearch).toHaveBeenCalledWith('a')
+    expect(onTrash).toHaveBeenCalledWith(t)
+  })
+
+  it('closes after an action runs', () => {
+    renderList([track({ id: 'a' })])
+    fireEvent.contextMenu(screen.getByTestId('track-row'))
+    fireEvent.click(screen.getByTestId('track-menu-reveal'))
+    expect(screen.queryByTestId('track-menu')).toBeNull()
+  })
+
+  it('closes on backdrop click without acting', () => {
+    renderList([track({ id: 'a' })])
+    fireEvent.contextMenu(screen.getByTestId('track-row'))
+    fireEvent.click(screen.getByTestId('track-menu-backdrop'))
+    expect(screen.queryByTestId('track-menu')).toBeNull()
+    expect(api.reveal).not.toHaveBeenCalled()
+  })
+
+  // The OS file manager and recycle location are named differently per platform.
+  it('uses Windows labels on win32', () => {
+    api.platform = 'win32'
+    renderList([track({ id: 'a' })])
+    fireEvent.contextMenu(screen.getByTestId('track-row'))
+    expect(screen.getByTestId('track-menu-reveal')).toHaveTextContent('Show in File Explorer')
+    expect(screen.getByTestId('track-menu-trash')).toHaveTextContent('Move to Recycle Bin')
   })
 })

--- a/apps/desktop/src/renderer/src/components/TrackList.tsx
+++ b/apps/desktop/src/renderer/src/components/TrackList.tsx
@@ -1,11 +1,12 @@
 import type React from 'react'
-import { memo } from 'react'
+import { memo, useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { OutputFormat } from '../../../shared/types'
 import { formatTime } from '../lib/duration'
 import { STAGE_PROGRESS } from '../lib/progress'
 import type { ClickMods } from '../lib/selection'
 import type { TrackItem, TrackStatus } from '../types'
+import { TrackContextMenu } from './TrackContextMenu'
 
 interface Props {
   tracks: TrackItem[]
@@ -15,7 +16,11 @@ interface Props {
   onSelect: (id: string, mods: ClickMods) => void
   onRemove: (id: string) => void
   onPrefetch: (id: string) => void
+  onSearch: (id: string) => void
+  onTrash: (track: TrackItem) => void
 }
+
+type MenuState = { track: TrackItem; x: number; y: number }
 
 const statusColor: Record<TrackStatus, string> = {
   idle: 'bg-fg-faint',
@@ -32,6 +37,7 @@ interface RowProps {
   onSelect: (id: string, mods: ClickMods) => void
   onRemove: (id: string) => void
   onPrefetch: (id: string) => void
+  onOpenMenu: (track: TrackItem, x: number, y: number) => void
 }
 
 // Memoized so a progress event — which replaces only the updated track's object
@@ -45,6 +51,7 @@ const TrackRow = memo(function TrackRow({
   onSelect,
   onRemove,
   onPrefetch,
+  onOpenMenu,
 }: RowProps): React.JSX.Element {
   const { t: tr } = useTranslation()
   // Every selected row gets the soft fill; only the primary (the one in the editor)
@@ -56,6 +63,13 @@ const TrackRow = memo(function TrackRow({
         data-testid="track-row"
         aria-selected={selected}
         onClick={(e) => onSelect(t.id, { meta: e.metaKey || e.ctrlKey, shift: e.shiftKey })}
+        onContextMenu={(e) => {
+          e.preventDefault()
+          // Make the right-clicked row the editor's track unless it's already part of
+          // the current selection, so the menu's single-track actions are unambiguous.
+          if (!selected) onSelect(t.id, {})
+          onOpenMenu(t, e.clientX, e.clientY)
+        }}
         onMouseEnter={() => onPrefetch(t.id)}
         onFocus={() => onPrefetch(t.id)}
         className={`relative flex w-full items-center gap-3 rounded-lg py-2.5 pr-10 pl-3 text-left transition-colors ${
@@ -125,7 +139,15 @@ export function TrackList({
   onSelect,
   onRemove,
   onPrefetch,
+  onSearch,
+  onTrash,
 }: Props): React.JSX.Element {
+  const [menu, setMenu] = useState<MenuState | null>(null)
+  // Stable so the memoized rows don't all re-render when the menu opens/closes.
+  const openMenu = useCallback(
+    (track: TrackItem, x: number, y: number) => setMenu({ track, x, y }),
+    [],
+  )
   return (
     <ul className="flex flex-col gap-1 p-2">
       {tracks.map((t) => (
@@ -138,8 +160,20 @@ export function TrackList({
           onSelect={onSelect}
           onRemove={onRemove}
           onPrefetch={onPrefetch}
+          onOpenMenu={openMenu}
         />
       ))}
+      {menu && (
+        <TrackContextMenu
+          track={menu.track}
+          x={menu.x}
+          y={menu.y}
+          onClose={() => setMenu(null)}
+          onSearch={onSearch}
+          onRemove={onRemove}
+          onTrash={onTrash}
+        />
+      )}
     </ul>
   )
 }

--- a/apps/desktop/src/renderer/src/components/TrackList.tsx
+++ b/apps/desktop/src/renderer/src/components/TrackList.tsx
@@ -61,7 +61,7 @@ const TrackRow = memo(function TrackRow({
       <button
         type="button"
         data-testid="track-row"
-        aria-selected={selected}
+        aria-pressed={selected}
         onClick={(e) => onSelect(t.id, { meta: e.metaKey || e.ctrlKey, shift: e.shiftKey })}
         onContextMenu={(e) => {
           e.preventDefault()

--- a/apps/desktop/src/renderer/src/components/useFocusTrap.test.tsx
+++ b/apps/desktop/src/renderer/src/components/useFocusTrap.test.tsx
@@ -49,11 +49,7 @@ describe('useFocusTrap', () => {
       const [open, setOpen] = useState(false)
       return (
         <>
-          <button
-            type="button"
-            data-testid="trigger"
-            onClick={() => setOpen((v) => !v)}
-          >
+          <button type="button" data-testid="trigger" onClick={() => setOpen((v) => !v)}>
             toggle
           </button>
           {open && <CloseOnMount />}

--- a/apps/desktop/src/renderer/src/components/useFocusTrap.ts
+++ b/apps/desktop/src/renderer/src/components/useFocusTrap.ts
@@ -13,7 +13,8 @@ export function useFocusTrap(ref: React.RefObject<HTMLElement | null>): void {
     const node = ref.current
     if (!node) return
     const previouslyFocused = document.activeElement as HTMLElement | null
-    const focusables = (): HTMLElement[] => Array.from(node.querySelectorAll<HTMLElement>(FOCUSABLE))
+    const focusables = (): HTMLElement[] =>
+      Array.from(node.querySelectorAll<HTMLElement>(FOCUSABLE))
 
     // Pull focus in if it isn't already inside, so the first Tab/Shift+Tab has a
     // known anchor. Components that focus their own input (e.g. the palette) keep

--- a/apps/desktop/src/renderer/src/i18n/locales/en.json
+++ b/apps/desktop/src/renderer/src/i18n/locales/en.json
@@ -201,7 +201,7 @@
     "targetLufs": "Target (LUFS)",
     "truePeak": "True peak (dBTP)",
     "peakDb": "Peak (dBFS)",
-    "cueWarning": "Heads up: this re-encodes the file, dropping any Traktor cue/beatgrid markers."
+    "cueWarning": "Re-encodes the audio. Traktor cues and beatgrid are kept for MP3 and AIFF, but dropped for WAV and FLAC."
   },
   "settings": {
     "tabs": {

--- a/apps/desktop/src/renderer/src/i18n/locales/en.json
+++ b/apps/desktop/src/renderer/src/i18n/locales/en.json
@@ -72,6 +72,16 @@
       "cover": "Preparing artwork…",
       "converting": "Converting to {{format}}…",
       "appleMusic": "Adding to Apple Music…"
+    },
+    "context": {
+      "reveal": "Reveal in Finder",
+      "revealWin": "Show in File Explorer",
+      "open": "Open file",
+      "copyPath": "Copy file path",
+      "search": "Search Discogs",
+      "remove": "Remove from list",
+      "trash": "Move to Trash",
+      "trashWin": "Move to Recycle Bin"
     }
   },
   "editor": {
@@ -93,6 +103,33 @@
     "analyzing": "Analyzing spectrum…",
     "sectionForm": "Metadata",
     "qualityCaption": "Reaches ~{{cutoff}} of {{nyquist}} (Nyquist). A sharp cutoff below it reveals an MP3 re-encoded as WAV.",
+    "loudnessLufsLabel": "Loudness",
+    "loudnessPeakLabel": "Peak",
+    "loudnessRangeLabel": "Range",
+    "loudnessLufsHint": "Integrated loudness (LUFS) — how loud the track sounds overall",
+    "loudnessPeakHint": "True peak (dBTP) — the loudest instant of the signal",
+    "loudnessRangeHint": "Loudness range (LU) — the spread between quiet and loud parts",
+    "loudnessGroupLoudness": "Loudness",
+    "loudnessGroupSignal": "Signal",
+    "loudnessCrestLabel": "Dynamics",
+    "loudnessCrestHint": "Crest factor (dB) — the punch between peaks and the average level",
+    "loudnessBalanceLabel": "Balance",
+    "loudnessBalanceHint": "Channel balance (dB) — the level difference between left and right",
+    "loudnessDcLabel": "DC offset",
+    "loudnessDcHint": "DC offset — a constant bias that shifts the waveform off centre",
+    "loudnessNoiseLabel": "Noise floor",
+    "loudnessNoiseHint": "Noise floor (dB) — the background level; lower is cleaner",
+    "loudnessHelpTitle": "What do these mean?",
+    "loudnessLufsHelp": "(LUFS) — how loud the track sounds overall. Too low and it plays quieter than your other tracks; too high and it sounds crushed.",
+    "loudnessPeakHelp": "(dBTP) — the loudest instant of the signal. Above 0 it can distort (clip) when converted or played back.",
+    "loudnessRangeHelp": "(LU) — how much the quiet and loud parts differ. A very low range means heavy compression (the loudness war).",
+    "loudnessCrestHelp": "(dB) — the gap between the peaks and the average level, i.e. the punch. A low figure means the track is squashed flat.",
+    "loudnessBalanceHelp": "(L/R) — the level difference between the left and right channels. A few dB means one side is weaker, often a misaligned cartridge on the rip.",
+    "loudnessDcHelp": "— a constant bias that shifts the whole waveform off centre. It wastes headroom and can add clicks; near 0% is healthy.",
+    "loudnessNoiseHelp": "(dB) — the level of the background hiss/noise. The lower (more negative), the cleaner the capture.",
+    "loudnessGradeGood": "Good",
+    "loudnessGradeWarn": "So-so",
+    "loudnessGradeBad": "Check it",
     "spectrumAlt": "Spectrogram",
     "spectrumCutoff": "cutoff ~{{cutoff}}",
     "output": "Output:",
@@ -145,9 +182,31 @@
     "publisher": "Label / Publisher",
     "catalogNumber": "Catalog No."
   },
+  "normalize": {
+    "title": "Loudness normalization",
+    "hint": "Off by default. Match every track to a target loudness or peak. It re-encodes the audio, so it drops Traktor cue/beatgrid markers.",
+    "mode": {
+      "none": "None",
+      "loudness": "Loudness",
+      "peak": "Peak"
+    },
+    "preset": {
+      "streaming": "Streaming −14",
+      "club": "Club −9",
+      "broadcast": "Broadcast −23",
+      "safe": "−1 dBFS",
+      "hot": "−0.1 dBFS",
+      "custom": "Custom"
+    },
+    "targetLufs": "Target (LUFS)",
+    "truePeak": "True peak (dBTP)",
+    "peakDb": "Peak (dBFS)",
+    "cueWarning": "Heads up: this re-encodes the file, dropping any Traktor cue/beatgrid markers."
+  },
   "settings": {
     "tabs": {
       "general": "General",
+      "conversion": "Conversion",
       "naming": "Editing",
       "artwork": "Artwork",
       "fields": "Fields",
@@ -195,6 +254,8 @@
     "coverHint": "Applied on embed: shrinks large artwork and, if enabled, center-crops it to square.",
     "showSpectrum": "Show audio spectrum",
     "showSpectrumHint": "Shows the spectrum and quality check while editing a track. When off, the analysis is skipped entirely.",
+    "showLoudness": "Show loudness (LUFS)",
+    "showLoudnessHint": "Measures integrated loudness, true peak and loudness range (EBU R128) while editing a track. When off, the measurement is skipped entirely.",
     "shown": "Shown",
     "hidden": "Hidden",
     "hide": "Hide",
@@ -275,6 +336,12 @@
     "clearTitle": "Clear the list?",
     "clearMessage_one": "This removes the only track from the list. The file on disk is not deleted.",
     "clearMessage_other": "This removes all {{count}} tracks from the list. The files on disk are not deleted.",
-    "clearConfirm": "Clear"
+    "clearConfirm": "Clear",
+    "trashTitle": "Move file to Trash?",
+    "trashTitleWin": "Move file to the Recycle Bin?",
+    "trashMessage": "This moves “{{name}}” to the Trash and removes it from the list. You can restore it from the Trash.",
+    "trashMessageWin": "This moves “{{name}}” to the Recycle Bin and removes it from the list. You can restore it from there.",
+    "trashConfirm": "Move to Trash",
+    "trashConfirmWin": "Move to Recycle Bin"
   }
 }

--- a/apps/desktop/src/renderer/src/i18n/locales/es.json
+++ b/apps/desktop/src/renderer/src/i18n/locales/es.json
@@ -201,7 +201,7 @@
     "targetLufs": "Objetivo (LUFS)",
     "truePeak": "Pico real (dBTP)",
     "peakDb": "Pico (dBFS)",
-    "cueWarning": "Aviso: esto recodifica el archivo y pierde los marcadores de cue/beatgrid de Traktor."
+    "cueWarning": "Recodifica el audio. Los cues y el beatgrid de Traktor se conservan en MP3 y AIFF, pero se pierden en WAV y FLAC."
   },
   "settings": {
     "tabs": {

--- a/apps/desktop/src/renderer/src/i18n/locales/es.json
+++ b/apps/desktop/src/renderer/src/i18n/locales/es.json
@@ -72,6 +72,16 @@
       "cover": "Preparando carátula…",
       "converting": "Convirtiendo a {{format}}…",
       "appleMusic": "Añadiendo a Apple Music…"
+    },
+    "context": {
+      "reveal": "Mostrar en Finder",
+      "revealWin": "Mostrar en el Explorador",
+      "open": "Abrir archivo",
+      "copyPath": "Copiar ruta del archivo",
+      "search": "Buscar en Discogs",
+      "remove": "Quitar de la lista",
+      "trash": "Mover a la papelera",
+      "trashWin": "Mover a la papelera de reciclaje"
     }
   },
   "editor": {
@@ -93,6 +103,33 @@
     "analyzing": "Analizando espectro…",
     "sectionForm": "Metadatos",
     "qualityCaption": "Llega a ~{{cutoff}} de {{nyquist}} (Nyquist). Un corte brusco por debajo delata un MP3 reconvertido a WAV.",
+    "loudnessLufsLabel": "Volumen",
+    "loudnessPeakLabel": "Pico",
+    "loudnessRangeLabel": "Rango",
+    "loudnessLufsHint": "Volumen integrado (LUFS): lo fuerte que suena la pista en conjunto",
+    "loudnessPeakHint": "Pico real (dBTP): el instante más alto de la señal",
+    "loudnessRangeHint": "Rango de loudness (LU): la diferencia entre las partes suaves y las fuertes",
+    "loudnessGroupLoudness": "Loudness",
+    "loudnessGroupSignal": "Señal",
+    "loudnessCrestLabel": "Dinámica",
+    "loudnessCrestHint": "Factor de cresta (dB): la pegada entre los picos y el nivel medio",
+    "loudnessBalanceLabel": "Balance",
+    "loudnessBalanceHint": "Balance de canales (dB): la diferencia de nivel entre izquierdo y derecho",
+    "loudnessDcLabel": "DC offset",
+    "loudnessDcHint": "DC offset: un desplazamiento constante que descentra la onda",
+    "loudnessNoiseLabel": "Ruido de fondo",
+    "loudnessNoiseHint": "Suelo de ruido (dB): el nivel de fondo; cuanto más bajo, más limpio",
+    "loudnessHelpTitle": "¿Qué significan?",
+    "loudnessLufsHelp": "(LUFS): lo fuerte que suena la pista en conjunto. Si es muy bajo, sonará más floja que tus otras pistas; si es muy alto, sonará aplastada.",
+    "loudnessPeakHelp": "(dBTP): el instante más alto de la señal. Por encima de 0 puede distorsionar (clipping) al convertir o reproducir.",
+    "loudnessRangeHelp": "(LU): cuánto se diferencian las partes suaves de las fuertes. Un rango muy bajo indica mucha compresión (la guerra del volumen).",
+    "loudnessCrestHelp": "(dB): la diferencia entre los picos y el nivel medio, es decir, la pegada. Un valor bajo significa que la pista está aplastada.",
+    "loudnessBalanceHelp": "(L/D): la diferencia de nivel entre los canales izquierdo y derecho. Unos dB indican que un lado suena más flojo, a menudo por una cápsula desalineada al ripear.",
+    "loudnessDcHelp": "— un desplazamiento constante que descentra toda la onda. Resta headroom y puede meter clics; cerca de 0% es lo sano.",
+    "loudnessNoiseHelp": "(dB): el nivel del siseo/ruido de fondo. Cuanto más bajo (más negativo), más limpia es la captura.",
+    "loudnessGradeGood": "Bien",
+    "loudnessGradeWarn": "Regular",
+    "loudnessGradeBad": "Revisar",
     "spectrumAlt": "Espectrograma",
     "spectrumCutoff": "corte ~{{cutoff}}",
     "output": "Salida:",
@@ -145,9 +182,31 @@
     "publisher": "Sello / Editora",
     "catalogNumber": "Nº catálogo"
   },
+  "normalize": {
+    "title": "Normalización de loudness",
+    "hint": "Desactivado por defecto. Iguala cada pista a un loudness o pico objetivo. Recodifica el audio, así que pierde los cue/beatgrid de Traktor.",
+    "mode": {
+      "none": "Ninguna",
+      "loudness": "Loudness",
+      "peak": "Pico"
+    },
+    "preset": {
+      "streaming": "Streaming −14",
+      "club": "Club −9",
+      "broadcast": "Broadcast −23",
+      "safe": "−1 dBFS",
+      "hot": "−0.1 dBFS",
+      "custom": "Personalizado"
+    },
+    "targetLufs": "Objetivo (LUFS)",
+    "truePeak": "Pico real (dBTP)",
+    "peakDb": "Pico (dBFS)",
+    "cueWarning": "Aviso: esto recodifica el archivo y pierde los marcadores de cue/beatgrid de Traktor."
+  },
   "settings": {
     "tabs": {
       "general": "General",
+      "conversion": "Conversión",
       "naming": "Edición",
       "artwork": "Carátula",
       "fields": "Campos",
@@ -195,6 +254,8 @@
     "coverHint": "Se aplica al embeber: reduce carátulas grandes y, si lo activas, recorta al centro para dejarlas cuadradas.",
     "showSpectrum": "Mostrar el espectro de audio",
     "showSpectrumHint": "Muestra el espectro y la comprobación de calidad al editar una pista. Si lo desactivas, el análisis se omite por completo.",
+    "showLoudness": "Mostrar el loudness (LUFS)",
+    "showLoudnessHint": "Mide el loudness integrado, el pico real y el rango de loudness (EBU R128) al editar una pista. Si lo desactivas, la medición se omite por completo.",
     "shown": "Mostrados",
     "hidden": "Ocultos",
     "hide": "Ocultar",
@@ -275,6 +336,12 @@
     "clearTitle": "¿Vaciar la lista?",
     "clearMessage_one": "Quita la única pista de la lista. El archivo en disco no se borra.",
     "clearMessage_other": "Quita las {{count}} pistas de la lista. Los archivos en disco no se borran.",
-    "clearConfirm": "Vaciar"
+    "clearConfirm": "Vaciar",
+    "trashTitle": "¿Mover el archivo a la papelera?",
+    "trashTitleWin": "¿Mover el archivo a la papelera de reciclaje?",
+    "trashMessage": "Esto mueve «{{name}}» a la papelera y lo quita de la lista. Puedes restaurarlo desde la papelera.",
+    "trashMessageWin": "Esto mueve «{{name}}» a la papelera de reciclaje y lo quita de la lista. Puedes restaurarlo desde ahí.",
+    "trashConfirm": "Mover a la papelera",
+    "trashConfirmWin": "Mover a la papelera de reciclaje"
   }
 }

--- a/apps/desktop/src/renderer/src/lib/outputName.test.ts
+++ b/apps/desktop/src/renderer/src/lib/outputName.test.ts
@@ -65,7 +65,12 @@ describe('renderOutputName', () => {
   it('keeps a "/" in the template as a subfolder boundary', () => {
     const r = renderOutputName(
       '{albumArtist}/{album}/{trackNumber} {title}',
-      meta({ albumArtist: 'Various', album: 'Hard House Nation', trackNumber: '01', title: 'Snap' }),
+      meta({
+        albumArtist: 'Various',
+        album: 'Hard House Nation',
+        trackNumber: '01',
+        title: 'Snap',
+      }),
     )
     expect(r).toBe('Various/Hard House Nation/01 Snap')
   })

--- a/apps/desktop/src/renderer/src/lib/quality.test.ts
+++ b/apps/desktop/src/renderer/src/lib/quality.test.ts
@@ -1,5 +1,17 @@
 import { describe, expect, it } from 'vitest'
-import { formatKHz, qualityVerdict } from './quality'
+import {
+  formatDb,
+  formatKHz,
+  formatPercent,
+  gradeBalance,
+  gradeCrest,
+  gradeDcOffset,
+  gradeLra,
+  gradeNoiseFloor,
+  gradeLufs,
+  gradeTruePeak,
+  qualityVerdict,
+} from './quality'
 
 describe('qualityVerdict', () => {
   it('passes a track whose energy reaches near Nyquist as good', () => {
@@ -25,5 +37,139 @@ describe('formatKHz', () => {
   it('renders hertz as a one-decimal kHz label for the UI', () => {
     expect(formatKHz(19961)).toBe('20.0 kHz')
     expect(formatKHz(16000)).toBe('16.0 kHz')
+  })
+})
+
+describe('formatDb', () => {
+  it('renders a loudness figure to one decimal for the readout', () => {
+    expect(formatDb(-14.73)).toBe('-14.7')
+    expect(formatDb(7.6)).toBe('7.6')
+  })
+
+  it('shows digital silence (-Infinity) as the minus-infinity glyph instead of "-Infinity"', () => {
+    expect(formatDb(-Infinity)).toBe('-∞')
+  })
+})
+
+// These colour-grade the loudness pills so a non-technical user reads the verdict
+// (green/amber/red) without having to understand the numbers — the whole point of
+// the readout. The thresholds target a DJ/streaming library, not mastering.
+describe('gradeTruePeak', () => {
+  it('flags a true peak above 0 dBFS as bad: it clips when re-encoded to a lossy codec or hits the DAC', () => {
+    expect(gradeTruePeak(2.5)).toBe('bad')
+    expect(gradeTruePeak(0.1)).toBe('bad')
+  })
+
+  it('warns inside the last dB of headroom, where inter-sample peaks get risky', () => {
+    expect(gradeTruePeak(0)).toBe('warn')
+    expect(gradeTruePeak(-0.5)).toBe('warn')
+  })
+
+  it('passes a peak with at least 1 dB of headroom as good', () => {
+    expect(gradeTruePeak(-1)).toBe('good')
+    expect(gradeTruePeak(-6)).toBe('good')
+    expect(gradeTruePeak(-Infinity)).toBe('good')
+  })
+})
+
+describe('gradeLufs', () => {
+  it('passes a track sitting in the loud-but-not-crushed band as good', () => {
+    expect(gradeLufs(-12)).toBe('good')
+    expect(gradeLufs(-16)).toBe('good')
+    expect(gradeLufs(-8)).toBe('good')
+  })
+
+  it('warns a track that is a touch quiet or a touch hot for a modern library', () => {
+    expect(gradeLufs(-18)).toBe('warn')
+    expect(gradeLufs(-7)).toBe('warn')
+  })
+
+  it('flags the extremes as bad: near-silence (a bad rip) or a crushed master', () => {
+    expect(gradeLufs(-70)).toBe('bad')
+    expect(gradeLufs(-Infinity)).toBe('bad')
+    expect(gradeLufs(-5)).toBe('bad')
+  })
+})
+
+describe('gradeBalance', () => {
+  it('passes a tightly matched pair of channels as good', () => {
+    expect(gradeBalance(0.8)).toBe('good')
+    expect(gradeBalance(0)).toBe('good')
+  })
+
+  it('warns a noticeable left/right imbalance', () => {
+    expect(gradeBalance(2)).toBe('warn')
+  })
+
+  it('flags a heavy imbalance as bad: one channel clearly weaker than the other', () => {
+    expect(gradeBalance(3)).toBe('bad')
+    expect(gradeBalance(9)).toBe('bad')
+  })
+})
+
+describe('gradeDcOffset', () => {
+  it('passes a clean, centred signal as good', () => {
+    expect(gradeDcOffset(0.00004)).toBe('good')
+  })
+
+  it('warns a small but present DC bias', () => {
+    expect(gradeDcOffset(0.005)).toBe('warn')
+  })
+
+  it('flags a large DC offset as bad: it wastes headroom and adds clicks', () => {
+    expect(gradeDcOffset(0.03)).toBe('bad')
+  })
+})
+
+describe('gradeCrest', () => {
+  it('passes a punchy peak-to-RMS spread as good', () => {
+    expect(gradeCrest(16)).toBe('good')
+    expect(gradeCrest(12)).toBe('good')
+  })
+
+  it('warns a track that is getting squashed', () => {
+    expect(gradeCrest(10)).toBe('warn')
+  })
+
+  it('flags a brick-walled, lifeless crest as bad', () => {
+    expect(gradeCrest(6)).toBe('bad')
+  })
+})
+
+describe('gradeNoiseFloor', () => {
+  it('passes a clean, quiet noise floor as good', () => {
+    expect(gradeNoiseFloor(-60)).toBe('good')
+    expect(gradeNoiseFloor(-45)).toBe('good')
+  })
+
+  it('warns an audible noise floor', () => {
+    expect(gradeNoiseFloor(-40)).toBe('warn')
+  })
+
+  it('flags a loud noise floor as bad: a noisy capture', () => {
+    expect(gradeNoiseFloor(-25)).toBe('bad')
+  })
+})
+
+describe('formatPercent', () => {
+  it('renders a 0..1 fraction as a one-decimal percentage for the DC offset pill', () => {
+    expect(formatPercent(0.00004)).toBe('0.0%')
+    expect(formatPercent(0.032)).toBe('3.2%')
+  })
+})
+
+describe('gradeLra', () => {
+  it('passes a track that keeps real dynamics as good', () => {
+    expect(gradeLra(7)).toBe('good')
+    expect(gradeLra(6)).toBe('good')
+  })
+
+  it('warns a moderately compressed track', () => {
+    expect(gradeLra(4)).toBe('warn')
+  })
+
+  it('flags a flat, brick-walled range as bad (the loudness-war signature)', () => {
+    expect(gradeLra(0)).toBe('bad')
+    expect(gradeLra(2)).toBe('bad')
   })
 })

--- a/apps/desktop/src/renderer/src/lib/quality.ts
+++ b/apps/desktop/src/renderer/src/lib/quality.ts
@@ -8,3 +8,81 @@ export function qualityVerdict(cutoffHz: number, sampleRateHz: number): Verdict 
 export function formatKHz(hz: number): string {
   return `${(hz / 1000).toFixed(1)} kHz`
 }
+
+// One-decimal label for a loudness figure (LUFS / dBTP / LU). A silent track
+// measures -Infinity, which would print "-Infinity"; show the ∞ glyph instead.
+export function formatDb(value: number): string {
+  if (!Number.isFinite(value)) return '-∞'
+  return value.toFixed(1)
+}
+
+// Three-step quality grade behind the loudness pills' colour (green/amber/red),
+// so the verdict is readable without understanding the number. Tuned for a
+// DJ/streaming library rather than mastering, and deliberately lenient in the
+// middle band. -Infinity (silence) falls out correctly: no peak is good, no
+// loudness is bad.
+export type Grade = 'good' | 'warn' | 'bad'
+
+// A true peak over 0 dBFS clips once the file is re-encoded to a lossy codec or
+// played through a DAC; the last dB of headroom is where inter-sample peaks bite.
+export function gradeTruePeak(dbtp: number): Grade {
+  if (dbtp > 0) return 'bad'
+  if (dbtp > -1) return 'warn'
+  return 'good'
+}
+
+// Integrated loudness: a wide "loud enough but not crushed" band is good, the
+// edges are a touch quiet/hot, and the extremes mean a broken-quiet rip or a
+// brick-walled master.
+export function gradeLufs(lufs: number): Grade {
+  if (lufs < -20 || lufs > -6) return 'bad'
+  if (lufs < -16 || lufs > -8) return 'warn'
+  return 'good'
+}
+
+// Loudness range is the soft-to-loud spread; a near-zero range is the
+// loudness-war signature of heavy compression.
+export function gradeLra(lra: number): Grade {
+  if (lra < 3) return 'bad'
+  if (lra < 6) return 'warn'
+  return 'good'
+}
+
+// Left/right level difference in dB: a tightly matched pair is fine, a few dB is
+// a noticeable lean, more is a clear imbalance (often a misaligned cartridge).
+export function gradeBalance(diffDb: number): Grade {
+  if (diffDb >= 3) return 'bad'
+  if (diffDb >= 1) return 'warn'
+  return 'good'
+}
+
+// DC offset as a fraction of full scale: digital rips are usually near zero, so
+// anything past ~1% points to a biased capture worth fixing.
+export function gradeDcOffset(offset: number): Grade {
+  if (offset >= 0.01) return 'bad'
+  if (offset >= 0.002) return 'warn'
+  return 'good'
+}
+
+// Crest factor in dB (peak − RMS): the transient punch. A healthy track keeps
+// some headroom over its average level; a squashed, brick-walled master collapses
+// toward the RMS.
+export function gradeCrest(crestDb: number): Grade {
+  if (crestDb < 8) return 'bad'
+  if (crestDb < 12) return 'warn'
+  return 'good'
+}
+
+// Noise floor in dB, lower (more negative) is cleaner. Graded leniently — a
+// continuously loud track has little quiet to measure, so only a clearly audible
+// floor is flagged.
+export function gradeNoiseFloor(floorDb: number): Grade {
+  if (floorDb > -30) return 'bad'
+  if (floorDb > -45) return 'warn'
+  return 'good'
+}
+
+// Renders a 0..1 fraction as a one-decimal percentage for the DC offset pill.
+export function formatPercent(fraction: number): string {
+  return `${(fraction * 100).toFixed(1)}%`
+}

--- a/apps/desktop/src/renderer/src/types.ts
+++ b/apps/desktop/src/renderer/src/types.ts
@@ -1,4 +1,10 @@
-import type { OutputFormat, ProcessStage, SpectrumResult, TrackMetadata } from '../../shared/types'
+import type {
+  LoudnessResult,
+  OutputFormat,
+  ProcessStage,
+  SpectrumResult,
+  TrackMetadata,
+} from '../../shared/types'
 
 export type TrackStatus = 'idle' | 'processing' | 'done' | 'error'
 
@@ -14,6 +20,9 @@ export interface TrackItem {
   coverUrl?: string
   coverPath?: string
   spectrum?: SpectrumResult
+  // EBU R128 loudness, measured once per input alongside the spectrum and shown
+  // read-only. null when the measurement failed; undefined before it has run.
+  loudness?: LoudnessResult | null
   outputName?: string
   status: TrackStatus
   stage?: ProcessStage

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -4,6 +4,22 @@ export type OutputFormat = 'aiff' | 'mp3' | 'wav' | 'flac'
 
 export type SearchProviderId = 'discogs'
 
+// Optional loudness normalization applied during conversion. 'none' is the default
+// so nothing is ever normalized unless the user opts in (globally in Settings or
+// per-track in the editor). 'loudness' targets an integrated LUFS with a true-peak
+// ceiling (two-pass loudnorm); 'peak' simply scales so the loudest sample hits a
+// target dBFS. Both re-encode the audio, so they drop the source's Traktor cues.
+export type NormalizeMode = 'none' | 'loudness' | 'peak'
+
+export interface NormalizeConfig {
+  mode: NormalizeMode
+  // 'loudness' mode: integrated target and true-peak ceiling.
+  targetLufs: number
+  truePeakDb: number
+  // 'peak' mode: the dBFS the loudest sample is scaled to.
+  peakDb: number
+}
+
 export interface Settings {
   theme: ThemePref
   discogsToken: string
@@ -19,6 +35,10 @@ export interface Settings {
   coverMaxSize: number
   coverSquare: boolean
   showSpectrum: boolean
+  showLoudness: boolean
+  // Default normalization applied to every conversion; mode 'none' (the default)
+  // means conversions never touch loudness unless overridden per-track.
+  normalize: NormalizeConfig
   hasSeenOnboarding: boolean
   conversionCount: number
 }
@@ -80,6 +100,9 @@ export interface ProcessJob {
   coverUrl?: string
   coverPath?: string
   format?: OutputFormat
+  // Per-track normalization override; falls back to the Settings default when
+  // undefined. Captured when the conversion starts, like format.
+  normalize?: NormalizeConfig
   // Where this track's last conversion landed, so re-exporting it overwrites its
   // own file silently while a collision with an unrelated file still prompts.
   previousOutputPath?: string
@@ -122,4 +145,26 @@ export interface SpectrumResult {
   // still rendered — the UI then hides the quality verdict instead of inventing one.
   cutoffHz: number | null
   sampleRateHz: number
+}
+
+// Read-only audio analysis shown beside the spectrum, measured in one ffmpeg pass
+// (astats + ebur128). Integrated loudness and true peak can read -Infinity for
+// digital silence, which the UI renders as "−∞" rather than a misleading number.
+export interface LoudnessResult {
+  integratedLufs: number
+  truePeakDb: number
+  lra: number
+  // The astats-derived checks are each null when not measurable (mono, a silent
+  // channel reading -inf, or ffmpeg printing nan) so the UI hides that pill rather
+  // than showing "−∞ dB" / "NaN%".
+  // |L − R| RMS difference in dB; null for mono or a dead channel. A large gap
+  // means a channel imbalance (e.g. a misaligned phono cartridge on the rip).
+  channelBalanceDb: number | null
+  // |DC offset| of the Overall mix (0..1 of full scale). A biased capture wastes
+  // headroom and adds clicks.
+  dcOffset: number | null
+  // Crest factor in dB (peak − RMS): the transient punch. Low means squashed.
+  crestDb: number | null
+  // Estimated noise floor in dB; lower is cleaner.
+  noiseFloorDb: number | null
 }

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -81,6 +81,11 @@
         "body": "AIFF, WAV, FLAC or MP3, any to any — lossless or a lighter MP3. Switch format anytime without re-importing. If it's already in the target format, Surco copies it untouched: same bits, instantly. One track or the whole crate at once."
       },
       {
+        "kick": "normalize",
+        "title": "Even out the loudness",
+        "body": "Optionally match every track to one loudness or peak — a streaming, club or custom target — so nothing jumps out when you mix. Off by default, and on MP3 and AIFF it keeps your Traktor cues."
+      },
+      {
         "kick": "traktor",
         "title": "Keeps your Traktor cues",
         "body": "Re-export to the same format (MP3 or AIFF) and Surco copies the audio untouched, keeping your Traktor cue points and beatgrid intact."
@@ -89,6 +94,11 @@
         "kick": "quality",
         "title": "No fakes, no duplicates",
         "body": "Check the spectrum at a glance to catch low-quality MP3s posing as lossless. And as you tag, Surco warns you if the track is already in your Apple Music library."
+      },
+      {
+        "kick": "analyze",
+        "title": "Read every level",
+        "body": "A colour-coded readout of each track — loudness (LUFS), true peak, dynamics, channel balance, DC offset and noise floor — green, amber or red at a glance, so a clipping or lopsided rip never slips into your set."
       },
       {
         "kick": "artwork",
@@ -199,6 +209,7 @@
         "Every format — AIFF, WAV, FLAC, MP3",
         "Discogs tagging and full-album match",
         "Spectrum analysis to catch fakes",
+        "Loudness readout and normalization",
         "Send straight to Apple Music",
         "Automatic updates"
       ]

--- a/apps/web/src/i18n/locales/es.json
+++ b/apps/web/src/i18n/locales/es.json
@@ -81,6 +81,11 @@
         "body": "AIFF, WAV, FLAC o MP3, de cualquiera a cualquiera — lossless o un MP3 más ligero. Cambia de formato cuando quieras sin reimportar. Si ya está en el formato de destino, lo copia tal cual: mismos bits, al instante. Una pista o la cola entera de una pasada."
       },
       {
+        "kick": "normaliza",
+        "title": "Iguala el volumen",
+        "body": "Si quieres, lleva cada pista al mismo loudness o pico — objetivo de streaming, club o personalizado — para que nada se dispare al mezclar. Desactivado por defecto, y en MP3 y AIFF conserva tus cue de Traktor."
+      },
+      {
         "kick": "traktor",
         "title": "Respeta tus CUE de Traktor",
         "body": "Al reexportar al mismo formato (MP3 o AIFF), Surco copia el audio tal cual y conserva intactos tus cue points y beatgrid de Traktor."
@@ -89,6 +94,11 @@
         "kick": "calidad",
         "title": "Sin fakes ni duplicados",
         "body": "Comprueba el espectro de un vistazo y caza los MP3 de baja calidad disfrazados de lossless. Y mientras etiquetas, Surco avisa si la pista ya está en tu biblioteca de Apple Music."
+      },
+      {
+        "kick": "analiza",
+        "title": "Lee cada nivel",
+        "body": "Una lectura con colores de cada pista — loudness (LUFS), pico real, dinámica, balance de canales, DC offset y ruido de fondo — verde, ámbar o rojo de un vistazo, para que un clipping o un rip descompensado no se cuele en tu sesión."
       },
       {
         "kick": "carátula",
@@ -199,6 +209,7 @@
         "Todos los formatos — AIFF, WAV, FLAC, MP3",
         "Etiquetado Discogs y emparejado de disco entero",
         "Análisis de espectro para cazar fakes",
+        "Lectura de loudness y normalización",
         "Envío directo a Apple Music",
         "Actualizaciones automáticas"
       ]


### PR DESCRIPTION
## Summary

Adds a read-only **audio analysis** readout and an opt-in **loudness normalization** step to the convert pipeline, and preserves Traktor cues through it.

> Note: this branch also bundles an in-progress **track row search + Move to Trash** feature (`Add track row search and Trash actions`, plus a lint-fix commit) that was developed in parallel and shares `App.tsx`/i18n with the audio work, so it could not be split out without interactive hunk-staging.

## Loudness & signal analysis (read-only)

A grouped stat grid under the spectrum, measured in **one ffmpeg pass** (`astats` + `ebur128`), each cell colour-graded green/amber/red (Tokyo Night tokens) with an ⓘ help modal:

- **Loudness** group: Integrated LUFS, True Peak (dBTP), Range (LRA), Dynamics (crest)
- **Signal** group: Balance (L/R), DC offset, Noise floor
- Non-finite readings (silent channel, `nan`) are dropped so cells never show `−∞`/`NaN`
- Toggle `showLoudness` in Settings

## Loudness normalization (opt-in)

- Modes `none | loudness | peak`; **default `none`** — nothing is normalized unless enabled
- `loudness` = two-pass linear `loudnorm` (target LUFS + true-peak ceiling); `peak` = `volumedetect` + constant gain
- Presets (Streaming/Club/Broadcast, safe/hot) **plus editable inputs** and an explicit **Custom** chip
- Configurable **globally** (new **Conversion** settings tab) and **per-track** (folded editor section with an active-mode badge)
- The convert button shows the active target so it's never a hidden setting
- `planConversion` never stream-copies when normalizing (forces re-encode)

## Traktor cue preservation

Normalizing re-encodes the audio (ffmpeg drops the GEOB cue/beatgrid frame), but a constant gain never moves cues in time — so `copyCueFrames` carries the source's GEOB frame verbatim into the output for **MP3/AIFF** (the ID3 containers it round-trips through). WAV/FLAC still lose them; the warning says so.

## Settings refactor

Split the overcrowded **General** tab into **General** (appearance + Discogs) and **Conversion** (output + normalization); reordered tabs by workflow.

## Testing

- ✅ 511 unit tests (Vitest) — new coverage for `parseLoudness`/`parseAstats`/grades, `normalize.ts`, `copyCueFrames`, the pills/grid, and the convert-button note
- ✅ `tsc --build` clean, `electron-vite build` packages cleanly
- ✅ Cue read→re-inject proven end-to-end against the bundled ffmpeg + TagLib (spike)
- ⚠️ GUI not driven (headless env) — interaction not exercised
