### PR TITLE
Keep TypeScript, Vite and @types/node majors out of the weekly dependabot batch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,16 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    # TypeScript 7 (Go port), Vite 8 and @types/node 26 are real migrations
+    # (baseUrl removed, TransferListItem gone, new Vite overloads) — they must
+    # be done by hand in a dedicated branch, not swept into the weekly batch.
+    ignore:
+      - dependency-name: typescript
+        update-types: ["version-update:semver-major"]
+      - dependency-name: vite
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
     groups:
       electron:
         patterns:


### PR DESCRIPTION
TS 7 / Vite 8 / @types/node 26 broke the grouped dependabot PR (#10) — they are real migrations (baseUrl removed, TransferListItem gone, new Vite overloads), not bumps. Ignore their majors so the weekly batch stays green; migrate them by hand later.