### PR TITLE
Align the Activity panel timers and the track list indicator columns

### DIFF
--- a/apps/desktop/src/renderer/src/components/ActivityPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/components/ActivityPanel.test.tsx
@@ -98,3 +98,42 @@ describe('ActivityPanel copy', () => {
     expect(screen.getByTestId('activity-copy')).toBeDisabled()
   })
 })
+
+describe('ActivityPanel timer alignment', () => {
+  // Timers form a right-aligned column the eye scans down. A row without a detail
+  // (no chevron) or without a release link (no open-in-browser button) used to let
+  // its timer slide right into the freed space, so the column jittered row by row.
+  // Every row must reserve those slots whether or not it fills them.
+  it('keeps the timer column identical across expandable, linked and plain rows', () => {
+    render(
+      <ActivityPanel
+        rows={[
+          {
+            id: 'expandable',
+            kind: 'discogs',
+            status: 'done',
+            label: 'Searching Discogs',
+            detail: 'GET /database/search',
+            ms: 4660,
+          },
+          {
+            id: 'linked',
+            kind: 'discogs',
+            status: 'done',
+            label: 'Loading Discogs release #301797',
+            url: 'https://www.discogs.com/release/301797',
+            ms: 4382,
+          },
+          { id: 'plain', kind: 'match', status: 'done', label: 'No match', ms: 20 },
+        ]}
+        onClear={vi.fn()}
+        onClose={vi.fn()}
+        onCopy={vi.fn()}
+        geometry={{ pos: { x: 0, y: 0 }, size: { width: 320, height: 360 } }}
+        onGeometryChange={vi.fn()}
+      />,
+    )
+    expect(screen.getAllByTestId('activity-chevron-slot')).toHaveLength(3)
+    expect(screen.getAllByTestId('activity-url-slot')).toHaveLength(3)
+  })
+})

--- a/apps/desktop/src/renderer/src/components/ActivityPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/ActivityPanel.tsx
@@ -128,17 +128,30 @@ function ChildRow({ row }: { row: ActivityRow }): React.JSX.Element {
         data-testid="activity-child"
         disabled={!expandable}
         onClick={() => setOpen((v) => !v)}
-        className="flex w-full items-center gap-2 py-1 pr-3 pl-9 text-left enabled:hover:bg-[var(--color-panel-2)] disabled:cursor-default"
+        className="flex w-full items-center gap-2 py-1 pl-9 text-left enabled:hover:bg-[var(--color-panel-2)] disabled:cursor-default"
       >
         <StatusIcon status={row.status} />
         <span className="min-w-0 flex-1 truncate text-[11px] text-fg-muted">
           {rowLabel(tr, row)}
         </span>
         {row.ms !== undefined && (
-          <span className="shrink-0 font-mono text-[10px] text-fg-muted">
+          <span className="shrink-0 text-right font-mono text-[10px] text-fg-muted tabular-nums">
             {tr('activity.elapsedMs', { ms: row.ms })}
           </span>
         )}
+        {/* Mirrors the parent rows' trailing slots (chevron + open-in-browser)
+            so child timers land in the same right-aligned column. */}
+        <span className="h-3 w-3 shrink-0">
+          {expandable && (
+            <ChevronRight
+              className={`h-3 w-3 text-fg-muted transition-transform ${open ? 'rotate-90' : ''}`}
+              aria-hidden="true"
+            />
+          )}
+        </span>
+        {/* ml-1 tops the button's gap-2 up to the parent rows' pr-3, keeping both
+            levels' timers on the exact same column. */}
+        <span className="mr-2 ml-1 h-6 w-6 shrink-0" />
       </button>
       {open && detail && (
         <pre className="max-h-32 overflow-auto whitespace-pre-wrap break-all px-3 pb-2 pl-12 font-mono text-[10px] text-fg-muted">
@@ -175,28 +188,37 @@ function Row({ row }: { row: ActivityRow }): React.JSX.Element {
             </span>
           )}
           {row.ms !== undefined && (
-            <span className="shrink-0 font-mono text-[10px] text-fg-muted">
+            <span className="shrink-0 text-right font-mono text-[10px] text-fg-muted tabular-nums">
               {tr('activity.elapsedMs', { ms: row.ms })}
             </span>
           )}
-          {expandable && (
-            <ChevronRight
-              className={`h-3 w-3 shrink-0 text-fg-muted transition-transform ${open ? 'rotate-90' : ''}`}
-              aria-hidden="true"
-            />
-          )}
+          {/* Always rendered so the timers form one right-aligned column: a row
+              with nothing to expand keeps the chevron's slot instead of letting
+              its timer drift into it. */}
+          <span data-testid="activity-chevron-slot" className="h-3 w-3 shrink-0">
+            {expandable && (
+              <ChevronRight
+                className={`h-3 w-3 text-fg-muted transition-transform ${open ? 'rotate-90' : ''}`}
+                aria-hidden="true"
+              />
+            )}
+          </span>
         </button>
-        {row.url && (
-          <button
-            type="button"
-            data-testid="activity-open-url"
-            aria-label={tr('activity.openInBrowser')}
-            onClick={() => row.url && openUrl(row.url)}
-            className="press mr-2 flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-fg-muted opacity-0 hover:bg-[var(--color-line-strong)] hover:text-fg group-hover:opacity-100"
-          >
-            <ExternalLink className="h-3.5 w-3.5" aria-hidden="true" />
-          </button>
-        )}
+        {/* Same slot discipline as the chevron: rows without a release link keep
+            the open-in-browser button's width so every timer ends at the same x. */}
+        <span data-testid="activity-url-slot" className="mr-2 h-6 w-6 shrink-0">
+          {row.url && (
+            <button
+              type="button"
+              data-testid="activity-open-url"
+              aria-label={tr('activity.openInBrowser')}
+              onClick={() => row.url && openUrl(row.url)}
+              className="press flex h-6 w-6 items-center justify-center rounded-md text-fg-muted opacity-0 hover:bg-[var(--color-line-strong)] hover:text-fg group-hover:opacity-100"
+            >
+              <ExternalLink className="h-3.5 w-3.5" aria-hidden="true" />
+            </button>
+          )}
+        </span>
       </div>
       {open && grouped && (
         <ul className="border-t border-[var(--color-line)] bg-[var(--color-panel-2)]/40">

--- a/apps/desktop/src/renderer/src/components/TrackList.test.tsx
+++ b/apps/desktop/src/renderer/src/components/TrackList.test.tsx
@@ -556,6 +556,20 @@ describe('TrackList format pill', () => {
     renderList([track({ id: 'a', inputPath: '/music/My.Crate/song', fileName: 'song' })])
     expect(screen.queryByTestId('track-format')).toBeNull()
   })
+
+  // The trailing indicators (sparkle, verdict, pill, duration) read as columns the
+  // eye scans down. The pill and duration render inside fixed-width slots that stay
+  // put whether the row has them or not — otherwise a FLAC pill next to an MP3 one,
+  // or a missing duration, shifts every icon to its left row by row.
+  it('reserves the pill and duration slots so the indicator columns never shift', () => {
+    renderList([
+      track({ id: 'flac', inputPath: '/music/a.flac', fileName: 'a', duration: 189 }),
+      track({ id: 'mp3', inputPath: '/music/b.mp3', fileName: 'b', duration: 412 }),
+      track({ id: 'bare', inputPath: '/music/c', fileName: 'c' }),
+    ])
+    expect(screen.getAllByTestId('track-format-slot')).toHaveLength(3)
+    expect(screen.getAllByTestId('track-duration-slot')).toHaveLength(3)
+  })
 })
 
 describe('TrackList quality badge', () => {

--- a/apps/desktop/src/renderer/src/components/TrackList.tsx
+++ b/apps/desktop/src/renderer/src/components/TrackList.tsx
@@ -403,22 +403,28 @@ const TrackRow = memo(function TrackRow({
                   )
                 )}
               </span>
-              {format && (
-                <span
-                  data-testid="track-format"
-                  className="shrink-0 rounded border border-[var(--color-line-strong)] px-1 text-[10px] font-medium leading-4 text-fg-dim"
-                >
-                  {format}
-                </span>
-              )}
-              {t.duration !== undefined && (
-                <span
-                  data-testid="track-duration"
-                  className="shrink-0 text-xs tabular-nums text-fg-dim"
-                >
-                  {formatTime(t.duration)}
-                </span>
-              )}
+              {/* Same slot discipline as the sparkle/verdict columns above: the pill
+                  and the duration get fixed-width slots so a wide FLAC pill next to
+                  an MP3 one — or a row still missing either value — never shifts the
+                  columns to its left. */}
+              <span data-testid="track-format-slot" className="flex w-10 shrink-0 justify-center">
+                {format && (
+                  <span
+                    data-testid="track-format"
+                    className="rounded border border-[var(--color-line-strong)] px-1 text-[10px] font-medium leading-4 text-fg-dim"
+                  >
+                    {format}
+                  </span>
+                )}
+              </span>
+              <span
+                data-testid="track-duration-slot"
+                className="w-[34px] shrink-0 text-right text-xs tabular-nums text-fg-dim"
+              >
+                {t.duration !== undefined && (
+                  <span data-testid="track-duration">{formatTime(t.duration)}</span>
+                )}
+              </span>
             </span>
           )}
         </span>


### PR DESCRIPTION
Every Activity row now reserves the chevron and open-in-browser slots (children mirror them), and the track row's format pill and duration render in fixed-width slots — so timers and per-row indicators form steady right-aligned columns instead of shifting with text length, missing links or absent values.