### PR TITLE
Upgrade Electron to 43.1.1

### DIFF
--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -3,7 +3,7 @@ productName: Surco
 # npm workspaces hoist electron to the repo-root node_modules, so electron-builder
 # run from apps/desktop can't infer the version — pin it explicitly. Keep in sync
 # with the electron devDependency.
-electronVersion: 42.6.1
+electronVersion: 43.1.1
 directories:
   buildResources: build
   output: dist

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -28,7 +28,7 @@
     "@types/react-dom": "^19.0.3",
     "@types/sql.js": "^1.4.11",
     "@vitejs/plugin-react": "^4.3.4",
-    "electron": "^42.6.1",
+    "electron": "^43.1.1",
     "electron-builder": "26.15.3",
     "electron-vite": "^3.0.0",
     "i18next": "^26.3.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,7 +62,7 @@
         "@types/react-dom": "^19.0.3",
         "@types/sql.js": "^1.4.11",
         "@vitejs/plugin-react": "^4.3.4",
-        "electron": "^42.6.1",
+        "electron": "^43.1.1",
         "electron-builder": "26.15.3",
         "electron-vite": "^3.0.0",
         "i18next": "^26.3.6",
@@ -3547,9 +3547,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "42.6.1",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-42.6.1.tgz",
-      "integrity": "sha512-HR9yiOyl+kZpSAugjOpBNvKpoh1wNpTK4wl6geD9W9Xmo6L6IgEzVB/JKlbEUDdXYeqRaaEhTUSSfyQ/g9iXvQ==",
+      "version": "43.1.1",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-43.1.1.tgz",
+      "integrity": "sha512-I5c5vfuVvaXpWx3IZdwvXgxQW44+e7OP1wXGVQkogLeSFSkUZ6sLCcWV05AdEcs65AO5tAIJJwbp7ixw+LdarA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
electron 42.6.1 → 43.1.1 (Chromium 148→150, V8 15.0), with the electron-builder.yml electronVersion pin bumped in the same change as its comment demands.

Why: 43 is a startup/IPC-focused release — main process boots from an embedded Node snapshot, framework bundles and preloads are cached as compiled V8 bytecode, sandboxed renderer startup no longer blocks on IPC, and IPC dispatch is optimized.

Breaking changes reviewed: none touch our surface (worker_threads, ipcMain, BrowserWindow, contextBridge, sandbox). The one behavioral change that applies: showOpenDialog without defaultPath now opens in Downloads instead of the OS-remembered last directory — affects our four open dialogs (import files/folder, destination pickers). Accepted as-is for now; if it annoys, we can track the last-used folder ourselves.

Verified: tsc --build clean, full suite green (2884), production build ok, and the real app driven end-to-end on 43 — import, player, analysis (worker_threads), waveform all working.