### PR TITLE
Upgrade @types/node to 26

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,15 +15,13 @@ updates:
     # done by hand in a dedicated branch, not swept into the weekly batch:
     # TypeScript 7 (Go port, baseUrl removed), Vite 8 (blocked until
     # electron-vite ships stable Vite 8 support — v6 is still in beta),
-    # @vitejs/plugin-react 6 (rolldown-only, requires Vite 8), @types/node 26
-    # (TransferListItem gone), react-router-dom 7 (new router API). Remove an
-    # entry once its migration lands.
+    # @vitejs/plugin-react 6 (rolldown-only, requires Vite 8),
+    # react-router-dom 7 (new router API). Remove an entry once its
+    # migration lands.
     ignore:
       - dependency-name: typescript
         update-types: ["version-update:semver-major"]
       - dependency-name: vite
-        update-types: ["version-update:semver-major"]
-      - dependency-name: "@types/node"
         update-types: ["version-update:semver-major"]
       - dependency-name: "@vitejs/plugin-react"
         update-types: ["version-update:semver-major"]

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -23,7 +23,7 @@
     "@tailwindcss/vite": "^4.3.2",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
-    "@types/node": "^22.20.1",
+    "@types/node": "^26.1.1",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.0.3",
     "@types/sql.js": "^1.4.11",

--- a/apps/desktop/src/main/worker.ts
+++ b/apps/desktop/src/main/worker.ts
@@ -1,5 +1,5 @@
 import os from 'node:os'
-import type { TransferListItem } from 'node:worker_threads'
+import type { Transferable } from 'node:worker_threads'
 import { createWorkerPool, type WorkerClient } from './workerClient'
 import type { WorkerJob, WorkerJobResult } from './workerJobs'
 
@@ -37,7 +37,7 @@ function getClient(): Promise<WorkerClient | null> {
 // loop (IPC, menu, surco:// streaming) never stalls behind DSP or TagLib rewrites.
 export async function runInWorker<T extends WorkerJobResult>(
   job: WorkerJob,
-  transfer?: readonly TransferListItem[],
+  transfer?: readonly Transferable[],
 ): Promise<T> {
   const client = await getClient()
   if (!client) return (await import('./workerJobs')).runWorkerJob(job) as T

--- a/apps/desktop/src/main/workerClient.ts
+++ b/apps/desktop/src/main/workerClient.ts
@@ -1,4 +1,4 @@
-import type { TransferListItem, Worker } from 'node:worker_threads'
+import type { Transferable, Worker } from 'node:worker_threads'
 import type { WorkerJob, WorkerJobResult } from './workerJobs'
 
 interface Pending {
@@ -8,7 +8,7 @@ interface Pending {
 
 interface Queued extends Pending {
   job: WorkerJob
-  transfer?: readonly TransferListItem[]
+  transfer?: readonly Transferable[]
 }
 
 interface WorkerResponse {
@@ -19,7 +19,7 @@ interface WorkerResponse {
 }
 
 export interface WorkerClient {
-  run: (job: WorkerJob, transfer?: readonly TransferListItem[]) => Promise<WorkerJobResult>
+  run: (job: WorkerJob, transfer?: readonly Transferable[]) => Promise<WorkerJobResult>
 }
 
 // Correlates jobs to responses over a single reused worker: spawning a thread costs

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,7 @@
         "@tailwindcss/vite": "^4.3.2",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
-        "@types/node": "^22.20.1",
+        "@types/node": "^26.1.1",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.0.3",
         "@types/sql.js": "^1.4.11",
@@ -3048,13 +3048,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.20.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
-      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~8.3.0"
       }
     },
     "node_modules/@types/react": {
@@ -7805,7 +7805,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "devOptional": true,
       "license": "MIT"
     },


### PR DESCRIPTION
@types/node 22 → 26.1.1 in apps/desktop, aligning the types with the Node 24 line Electron 43 actually ships. The only breakage: TransferListItem was removed from node:worker_threads — replaced with its successor type Transferable in worker.ts and workerClient.ts (type-only change, zero runtime impact). Verified beyond tsc: full suite green (2884) and the real app's worker-based audio analysis completes. Drops @types/node from the dependabot major-ignore list.