### PR TITLE
Document that react-router-dom 7 is blocked by vite-react-ssg

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,8 +15,9 @@ updates:
     # done by hand in a dedicated branch, not swept into the weekly batch:
     # Vite 8 (blocked until electron-vite ships stable Vite 8 support — v6
     # is still in beta), @vitejs/plugin-react 6 (rolldown-only, requires
-    # Vite 8), react-router-dom 7 (new router API). Remove an entry once its
-    # migration lands.
+    # Vite 8), react-router-dom 7 (blocked: vite-react-ssg peers at ^6.14.1
+    # with no v7-compatible release). Remove an entry once its migration
+    # lands.
     ignore:
       - dependency-name: vite
         update-types: ["version-update:semver-major"]


### PR DESCRIPTION
Attempted the react-router-dom 7 migration and hit a hard wall: vite-react-ssg (0.9.2, latest) peers at react-router-dom ^6.14.1 with no v7-compatible release, and the web app's routing is mounted by vite-react-ssg. Updated the ignore-list comment so the real blocker is on record — same as the Vite 8 entry.